### PR TITLE
Disable check PDF manual on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,29 @@ r:
 - release
 - oldrel
 
+# TeXLive issues for osx images
+# https://travis-ci.community/t/latex-error-file-inconsolata-sty-not-found-only-on-osx-when-building-r-package/3261/4
 os:
 - linux
-- osx
+# - osx
 
-# Newer default osx images have issues with TeXLive
-# https://travis-ci.community/t/latex-error-file-inconsolata-sty-not-found-only-on-osx-when-building-r-package/3261/4
 osx_image: xcode9.2
 
 # Vanilla macOS machine: remove preinstalled homebrew installation
 disable_homebrew: true
 
 jobs:
-  exclude:
-  # macOS binary packages not available for r-devel
-  - r: devel
+#  exclude:
+#  # macOS binary packages not available for r-devel
+#  - r: devel
+#    os: osx
+  include:
+  - r: release
     os: osx
+    r_check_args: --no-manual
+  - r: oldrel
+    os: osx
+    r_check_args: --no-manual
 
 # Code coverage
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ os:
 - linux
 - osx
 
+# The default osx image (xcode9.4) has issues with TeXLive 2020 being just released
+# https://travis-ci.community/t/latex-error-file-inconsolata-sty-not-found-only-on-osx-when-building-r-package/3261/4
+osx_image: xcode9.3
+
 # Vanilla macOS machine: remove preinstalled homebrew installation
 disable_homebrew: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ os:
 - linux
 - osx
 
-# The default osx image (xcode9.4) has issues with TeXLive 2020 being just released
+# Newer default osx images have issues with TeXLive
 # https://travis-ci.community/t/latex-error-file-inconsolata-sty-not-found-only-on-osx-when-building-r-package/3261/4
-osx_image: xcode9.3
+osx_image: xcode9.2
 
 # Vanilla macOS machine: remove preinstalled homebrew installation
 disable_homebrew: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,10 @@ r:
 
 # TeXLive issues for osx images
 # https://travis-ci.community/t/latex-error-file-inconsolata-sty-not-found-only-on-osx-when-building-r-package/3261/4
+
 os:
 - linux
 # - osx
-
-osx_image: xcode9.2
 
 # Vanilla macOS machine: remove preinstalled homebrew installation
 disable_homebrew: true


### PR DESCRIPTION
See also https://travis-ci.community/t/latex-error-file-inconsolata-sty-not-found-only-on-osx-when-building-r-package/3261/4

At the moment there seem to be no workaround, so we are disabling the PDF manual check on macOS