### PR TITLE
Use a test helper to define the expected C++ error class (fixes #15)

### DIFF
--- a/tests/testthat/helper-invalid_argument.R
+++ b/tests/testthat/helper-invalid_argument.R
@@ -1,0 +1,34 @@
+# Work around the fact that, in certain circumstances (architectures /
+# compilers), we cannot rely on errors propagating with proper
+# `std::invalid_argument` class / error message.
+#
+# See https://github.com/miraisolutions/rTRNG/issues/15,
+# https://github.com/RcppCore/Rcpp/issues/972
+#
+# Approach: Use a minimal example to test whether "std::invalid_argument" is
+# correctly detected, otherwise just fall-back on "error" (the "c++ exception
+# (unknown reason)" error inherits from it).
+
+invalid_argument_thrower <- cppFunction('
+  void invalid_argument_thrower() {
+    throw std::invalid_argument("Invalid argument test");
+  }
+')
+
+invalid_argument_error_class <- function() {
+  error_class <- tryCatch(
+    invalid_argument_thrower(),
+    error = function(e) class(e)
+  )
+  error_class
+}
+
+supported_invalid_argument_class <- function() {
+  if ("std::invalid_argument" %in% invalid_argument_error_class()) {
+    "std::invalid_argument"
+  } else {
+    "error"
+  }
+}
+
+expected_invalid_argument_class <- supported_invalid_argument_class()

--- a/tests/testthat/test-TRNG.Engine.R
+++ b/tests/testthat/test-TRNG.Engine.R
@@ -262,11 +262,11 @@ test_that("$split errors for out-of-range subsequence indices", {
     p <- 5L
     if (!grepl("(lagfib|mt)", engineClass)) {
       expect_error(
-        e$split(p, 0L), class = "std::invalid_argument", # 1-base indexing
+        e$split(p, 0L), class = expected_invalid_argument_class, # 1-base indexing
         info = .name(engineClass)
       )
       expect_error(
-        e$split(p, p + 1L), class = "std::invalid_argument",
+        e$split(p, p + 1L), class = expected_invalid_argument_class,
         info = .name(engineClass)
       )
       expect_error(

--- a/tests/testthat/test-TRNG.Random.R
+++ b/tests/testthat/test-TRNG.Random.R
@@ -131,8 +131,8 @@ test_that("TRNGsplit errors for out-of-range subsequence indices", {
   TRNGkind(KIND)
   TRNGseed(SEED)
   p <- 5L
-  expect_error(TRNGsplit(p, 0L), class = "std::invalid_argument") # 1-base indexing
-  expect_error(TRNGsplit(p, p + 1L), class = "std::invalid_argument")
+  expect_error(TRNGsplit(p, 0L), class = expected_invalid_argument_class) # 1-base indexing
+  expect_error(TRNGsplit(p, p + 1L), class = expected_invalid_argument_class)
   expect_error(TRNGsplit(p, -1L), "negative")
   expect_error(TRNGsplit(-1L, 1L), "negative")
 })


### PR DESCRIPTION
Fixes #15

* This works around the fact that, in certain circumstances, we cannot rely on errors propagating with proper `std::invalid_argument` class / error message. See also RcppCore/Rcpp#972

To be merged into the branch for #14, where the issue was revealed.