### PR TITLE
Underlying TRNG C++ library updated to v4.23(.1)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^cran-comments\.md$
 LICENSE
 ^\.github$
+^valgrind-check$

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -9,7 +9,7 @@ jobs:
     # Always run only on master, otherwise only if "[valgrind-check]" appears
     # in the commit comment. An empty commit can be used as follows:
     #   git commit --allow-empty -m 'Trigger [valgrind-check]'
-    if: contains(github.event.head_commit.message, '[valgrind-check]') || github.ref == 'refs/heads/master' || github.base_ref == 'refs/heads/master'
+    if: contains(github.event.head_commit.message, '[valgrind-check]') || github.ref == 'refs/heads/master' || github.event.pull_request.base.ref == 'master'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -1,0 +1,37 @@
+# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
+# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+on: [push, pull_request]
+
+name: valgrind
+
+jobs:
+  valgrind-check:
+    # Always run only on master, otherwise only if "[valgrind-check]" appears
+    # in the commit comment. An empty commit can be used as follows:
+    #   git commit --allow-empty -m 'Trigger [valgrind-check]'
+    if: contains(github.event.head_commit.message, '[valgrind-check]') || github.ref == 'refs/heads/master' || github.base_ref == 'refs/heads/master'
+
+    runs-on: ubuntu-latest
+
+    name: valgrind-check
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check with valgrind
+        run: bash inst/tools/valgrind-check.sh
+
+      - name: Detect valgrind issues
+        working-directory: valgrind-check
+        run: |
+          if grep -iv "ERROR SUMMARY: 0 errors" valgrind-summary; then
+            echo "::error ::Found valgrind errors"
+            exit 1
+          fi
+
+      - name: Upload valgrind results
+        if: always()
+        uses: actions/upload-artifact@main
+        with:
+          name: valgrind-results
+          path: valgrind-check

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/*.dll
 src/trng/*.o
 src/trng/*.so
 inst/doc
+valgrind-check

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,8 +15,8 @@ Description: Embeds sources and headers from Tina's Random
     easier access, testing and benchmarking into R. Provides examples of
     how to use parallel RNG with 'RcppParallel'. The methods and
     techniques behind 'TRNG' are illustrated in the package vignettes and
-    examples. Full documentation is available in Bauke (2018)
-    <https://numbercrunch.de/trng/trng.pdf>.
+    examples. Full documentation is available in Bauke (2021)
+    <https://github.com/rabauke/trng4/tree/v4.23.1/doc/trng.pdf>.
 License: GPL-3
 URL: https://github.com/miraisolutions/rTRNG#readme,
     https://mirai-solutions.ch

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rTRNG
 Title: Advanced and Parallel Random Number Generation via 'TRNG'
-Version: 4.22-1.9000
+Version: 4.23-0.9000
 Authors@R: 
     c(person("Riccardo", "Porreca", role = c("aut", "cre"),
              email = "riccardo.porreca@mirai-solutions.com"),
@@ -41,7 +41,7 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 NeedsCompilation: yes
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Collate: 
     'LdFlags.R'
     'RcppExports.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rTRNG
 Title: Advanced and Parallel Random Number Generation via 'TRNG'
-Version: 4.23-0.9000
+Version: 4.23.1-0.9000
 Authors@R: 
     c(person("Riccardo", "Porreca", role = c("aut", "cre"),
              email = "riccardo.porreca@mirai-solutions.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # rTRNG (development version)
 
+- Underlying TRNG C++ library upgraded to version 4.23 (#18). This is a maintenance release, mainly including: Enhanced numerical accuracy of several special mathematical functions; Re-implementation of the discard method of the lagged Fibonacci generators with logarithmic asymptotic complexity.
 - Continuous integration is now based on GitHub Actions and covers R-release, R-oldrel and R-devel on Ubuntu, macOS and Windows (#14).
 - Unit tests for "invalid argument" errors are now robust to systems where the error class does not propagate correctly to R, such as R 3.6.3 on macOS (#15).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # rTRNG (development version)
 
-- Underlying TRNG C++ library upgraded to version 4.23 (#18). This is a maintenance release, mainly including: Enhanced numerical accuracy of several special mathematical functions; Re-implementation of the discard method of the lagged Fibonacci generators with logarithmic asymptotic complexity.
-- Continuous integration is now based on GitHub Actions and covers R-release, R-oldrel and R-devel on Ubuntu, macOS and Windows (#14).
+- Underlying TRNG C++ library upgraded to version 4.23.1 (#20). This maintenance release, mainly including: Enhanced numerical accuracy of several special mathematical functions; Re-implementation of the discard method of the lagged Fibonacci generators with logarithmic asymptotic complexity. The release also fixes the uninitialized-memory problems reported as `valgrind` issues in the CRAN package checks for rTRNG 4.20-1 (#16).
+- Continuous integration is now based on GitHub Actions and covers R-release, R-oldrel and R-devel on Ubuntu, macOS and Windows (#14), as well as running checks with `valgrind` (#16).
 - Unit tests for "invalid argument" errors are now robust to systems where the error class does not propagate correctly to R, such as R 3.6.3 on macOS (#15).
 
 # rTRNG 4.22-1

--- a/R/TRNG.Version.R
+++ b/R/TRNG.Version.R
@@ -4,5 +4,5 @@
 #'
 #' @export
 TRNG.Version <- function() {
-  return("4.23")
+  return("4.23.1 (patched in rTRNG)")
 }

--- a/R/TRNG.Version.R
+++ b/R/TRNG.Version.R
@@ -4,5 +4,5 @@
 #'
 #' @export
 TRNG.Version <- function() {
-  return("4.23.1 (patched in rTRNG)")
+  return("4.23.1")
 }

--- a/R/TRNG.Version.R
+++ b/R/TRNG.Version.R
@@ -4,5 +4,5 @@
 #'
 #' @export
 TRNG.Version <- function() {
-  return("4.22")
+  return("4.23")
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,7 +40,7 @@ stop_if_no_vignette <- function(topic, package = "rTRNG") {
 
 [![CRAN status](http://www.r-pkg.org/badges/version/rTRNG)](https://cran.r-project.org/package=rTRNG)
 [![R-CMD-check](https://github.com/miraisolutions/rTRNG/workflows/R-CMD-check/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3AR-CMD-check)
-[![Codecov status](https://img.shields.io/codecov/c/github/miraisolutions/rTRNG/master.svg)](https://codecov.io/github/miraisolutions/rTRNG?branch=master)
+[![Codecov coverage](https://codecov.io/gh/miraisolutions/rTRNG/branch/master/graph/badge.svg)](https://codecov.io/gh/miraisolutions/rTRNG?branch=master)
 
 **[TRNG](https://numbercrunch.de/trng/)** (Tina's Random Number Generator) is a
 state-of-the-art C++ pseudo-random number generator library for sequential and

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,6 +40,7 @@ stop_if_no_vignette <- function(topic, package = "rTRNG") {
 
 [![CRAN status](http://www.r-pkg.org/badges/version/rTRNG)](https://cran.r-project.org/package=rTRNG)
 [![R-CMD-check](https://github.com/miraisolutions/rTRNG/workflows/R-CMD-check/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3AR-CMD-check)
+ [![valgrind](https://github.com/miraisolutions/rTRNG/workflows/valgrind/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3Avalgrind)
 [![Codecov coverage](https://codecov.io/gh/miraisolutions/rTRNG/branch/master/graph/badge.svg)](https://codecov.io/gh/miraisolutions/rTRNG?branch=master)
 
 **[TRNG](https://numbercrunch.de/trng/)** (Tina's Random Number Generator) is a

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 status](http://www.r-pkg.org/badges/version/rTRNG)](https://cran.r-project.org/package=rTRNG)
 [![R-CMD-check](https://github.com/miraisolutions/rTRNG/workflows/R-CMD-check/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3AR-CMD-check)
 [![Codecov
-status](https://img.shields.io/codecov/c/github/miraisolutions/rTRNG/master.svg)](https://codecov.io/github/miraisolutions/rTRNG?branch=master)
+coverage](https://codecov.io/gh/miraisolutions/rTRNG/branch/master/graph/badge.svg)](https://codecov.io/gh/miraisolutions/rTRNG?branch=master)
 
 **[TRNG](https://numbercrunch.de/trng/)** (Tina’s Random Number
 Generator) is a state-of-the-art C++ pseudo-random number generator

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![CRAN
 status](http://www.r-pkg.org/badges/version/rTRNG)](https://cran.r-project.org/package=rTRNG)
 [![R-CMD-check](https://github.com/miraisolutions/rTRNG/workflows/R-CMD-check/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3AR-CMD-check)
+[![valgrind](https://github.com/miraisolutions/rTRNG/workflows/valgrind/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3Avalgrind)
 [![Codecov
 coverage](https://codecov.io/gh/miraisolutions/rTRNG/branch/master/graph/badge.svg)](https://codecov.io/gh/miraisolutions/rTRNG?branch=master)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,14 @@
 comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true

--- a/inst/COPYRIGHTS
+++ b/inst/COPYRIGHTS
@@ -1,6 +1,6 @@
 ** rTRNG includes source code from Tina's Random Number Generator C++ Library **
 
-Copyright (c) 2000-2019, Heiko Bauke
+Copyright (c) 2000-2020, Heiko Bauke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/inst/include/trng/bernoulli_dist.hpp
+++ b/inst/include/trng/bernoulli_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,7 @@
 #include <trng/utility.hpp>
 #include <ostream>
 #include <istream>
+#include <type_traits>
 #include <ciso646>
 
 namespace trng {
@@ -47,13 +48,33 @@ namespace trng {
   template<typename T>
   class bernoulli_dist {
   public:
-    typedef T result_type;
-    class param_type;
+    using result_type = T;
 
     class param_type {
+      template<typename type>
+      static constexpr typename std::enable_if<std::is_arithmetic<type>::value, type>::type
+      init_head() {
+        return type(0);
+      }
+      template<typename type>
+      static constexpr typename std::enable_if<not std::is_arithmetic<type>::value, type>::type
+      init_head() {
+        return type{};
+      }
+      template<typename type>
+      static constexpr typename std::enable_if<std::is_arithmetic<type>::value, type>::type
+      init_tail() {
+        return type(1);
+      }
+      template<typename type>
+      static constexpr typename std::enable_if<not std::is_arithmetic<type>::value, type>::type
+      init_tail() {
+        return type{};
+      }
+
     private:
       double p_{0.5};
-      T head_{}, tail_{};
+      T head_{init_head<T>()}, tail_{init_tail<T>()};
 
     public:
       TRNG_CUDA_ENABLE
@@ -70,7 +91,13 @@ namespace trng {
       void tail(const T &tail_new) { tail_ = tail_new; }
       param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(double p, const T &head, const T &tail) : p_(p), head_(head), tail_(tail) {}
+      explicit param_type(double p) : p_{p} {
+        static_assert(std::is_arithmetic<T>::value,
+                      "head and tail values must be specified explicitly");
+      }
+      TRNG_CUDA_ENABLE
+      explicit param_type(double p, const T &head, const T &tail)
+          : p_{p}, head_{head}, tail_{tail} {}
       friend class bernoulli_dist;
     };
 
@@ -80,9 +107,11 @@ namespace trng {
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    bernoulli_dist(double p, const T &head, const T &tail) : P(p, head, tail) {}
+    explicit bernoulli_dist(double p) : P{p} {}
     TRNG_CUDA_ENABLE
-    explicit bernoulli_dist(const param_type &P) : P(P) {}
+    explicit bernoulli_dist(double p, const T &head, const T &tail) : P{p, head, tail} {}
+    TRNG_CUDA_ENABLE
+    explicit bernoulli_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -98,9 +127,15 @@ namespace trng {
     }
     // property methods
     TRNG_CUDA_ENABLE
-    T min() const { return P.head(); }
+    T min() const {
+      static_assert(std::is_arithmetic<T>::value, "result_type must be an arithmetic type");
+      return P.head() < P.tail() ? P.head() : P.tail();
+    }
     TRNG_CUDA_ENABLE
-    T max() const { return P.tail(); }
+    T max() const {
+      static_assert(std::is_arithmetic<T>::value, "result_type must be an arithmetic type");
+      return P.head() > P.tail() ? P.head() : P.tail();
+    }
     TRNG_CUDA_ENABLE
     param_type param() const { return P; }
     TRNG_CUDA_ENABLE
@@ -108,7 +143,7 @@ namespace trng {
     TRNG_CUDA_ENABLE
     double p() const { return P.p(); }
     TRNG_CUDA_ENABLE
-    void p(double p_new) { P.p(p_new); }
+    void p(double P_new) { P.p(P_new); }
     TRNG_CUDA_ENABLE
     T head() const { return P.head(); }
     TRNG_CUDA_ENABLE
@@ -122,18 +157,27 @@ namespace trng {
     double pdf(const T &x) const {
       if (x == P.head())
         return P.p();
-      else if (x == P.tail())
+      if (x == P.tail())
         return 1.0 - P.p();
       return 0.0;
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     double cdf(const T &x) const {
-      if (x == P.head())
-        return P.p();
-      else if (x == P.tail())
+      static_assert(std::is_arithmetic<T>::value, "result_type must be an arithmetic type");
+      if (P.head() < P.tail()) {
+        if (x < P.head())
+          return 0.0;
+        if (x < P.tail())
+          return P.p();
         return 1.0;
-      return 0.0;
+      } else {
+        if (x < P.tail())
+          return 0.0;
+        if (x < P.head())
+          return 1.0 - P.p();
+        return 1.0;
+      }
     }
   };
 
@@ -141,14 +185,14 @@ namespace trng {
 
   // EqualityComparable concept
   template<typename T>
-  TRNG_CUDA_ENABLE inline bool operator==(const typename bernoulli_dist<T>::param_type &p1,
-                                          const typename bernoulli_dist<T>::param_type &p2) {
-    return p1.p() == p2.p() and p1.head() == p2.head() and p1.tail() == p2.tail();
+  TRNG_CUDA_ENABLE inline bool operator==(const typename bernoulli_dist<T>::param_type &P1,
+                                          const typename bernoulli_dist<T>::param_type &P2) {
+    return P1.p() == P2.p() and P1.head() == P2.head() and P1.tail() == P2.tail();
   }
   template<typename T>
-  TRNG_CUDA_ENABLE inline bool operator!=(const typename bernoulli_dist<T>::param_type &p1,
-                                          const typename bernoulli_dist<T>::param_type &p2) {
-    return !(p1 == p2);
+  TRNG_CUDA_ENABLE inline bool operator!=(const typename bernoulli_dist<T>::param_type &P1,
+                                          const typename bernoulli_dist<T>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // Streamable concept
@@ -206,12 +250,12 @@ namespace trng {
   template<typename char_t, typename traits_t, typename T>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    bernoulli_dist<T> &g) {
-    typename bernoulli_dist<T>::param_type p;
+    typename bernoulli_dist<T>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[bernoulli ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[bernoulli ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/beta_dist.hpp
+++ b/inst/include/trng/beta_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -52,12 +52,11 @@ namespace trng {
   template<typename float_t = double>
   class beta_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type alpha_, beta_, norm_;
+      result_type alpha_{1}, beta_{1}, norm_{math::Beta(alpha_, beta_)};
 
     public:
       TRNG_CUDA_ENABLE
@@ -80,61 +79,60 @@ namespace trng {
         beta_ = beta_new;
         norm_ = math::Beta(alpha_, beta_);
       }
-      param_type() : alpha_(1), beta_(1), norm_(math::Beta(alpha_, beta_)) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(result_type alpha, result_type beta)
-          : alpha_(alpha), beta_(beta), norm_(math::Beta(alpha, beta)) {}
+      explicit param_type(result_type alpha, result_type beta) : alpha_{alpha}, beta_{beta} {}
 
       friend class beta_dist;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1)
-            << p.alpha() << ' ' << p.beta() << ')';
+            << P.alpha() << ' ' << P.beta() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t alpha, beta;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> alpha >> utility::delim(' ') >> beta >>
             utility::delim(')');
         if (in)
-          p = param_type(alpha, beta);
+          P = param_type(alpha, beta);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    beta_dist(result_type alpha, result_type beta) : p(alpha, beta) {}
+    explicit beta_dist(result_type alpha, result_type beta) : P{alpha, beta} {}
     TRNG_CUDA_ENABLE
-    explicit beta_dist(const param_type &p) : p(p) {}
+    explicit beta_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
     // random numbers
     template<typename R>
     TRNG_CUDA_ENABLE result_type operator()(R &r) {
-      return math::inv_Beta_I(utility::uniformoo<result_type>(r), p.alpha(), p.beta(),
-                              p.norm());
+      return math::inv_Beta_I(utility::uniformoo<result_type>(r), P.alpha(), P.beta(),
+                              P.norm());
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      beta_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      beta_dist g(P);
       return g(r);
     }
     // property methods
@@ -143,25 +141,25 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return result_type(1); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &P_new) { P = P_new; }
     TRNG_CUDA_ENABLE
-    result_type alpha() const { return p.alpha(); }
+    result_type alpha() const { return P.alpha(); }
     TRNG_CUDA_ENABLE
-    result_type beta() const { return p.beta(); }
+    result_type beta() const { return P.beta(); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
       if (x < 0 or x > 1)
         return 0;
-      if ((x == 0 and p.alpha() - 1 < 0) or (x == 1 and p.beta() - 1 < 0)) {
+      if ((x == 0 and P.alpha() - 1 < 0) or (x == 1 and P.beta() - 1 < 0)) {
 #if !(defined __CUDA_ARCH__)
         errno = EDOM;
 #endif
         return math::numeric_limits<result_type>::quiet_NaN();
       }
-      return 1 / p.norm() * math::pow(x, p.alpha() - 1) * math::pow(1 - x, p.beta() - 1);
+      return 1 / P.norm() * math::pow(x, P.alpha() - 1) * math::pow(1 - x, P.beta() - 1);
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
@@ -170,7 +168,7 @@ namespace trng {
         return 0;
       if (x >= 1)
         return 1;
-      return math::Beta_I(x, p.alpha(), p.beta(), p.norm());
+      return math::Beta_I(x, P.alpha(), P.beta(), P.norm());
     }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
@@ -185,7 +183,7 @@ namespace trng {
         return 0;
       if (x == 1)
         return 1;
-      return math::inv_Beta_I(x, p.alpha(), p.beta(), p.norm());
+      return math::inv_Beta_I(x, P.alpha(), P.beta(), P.norm());
     }
   };
 
@@ -193,15 +191,15 @@ namespace trng {
 
   // EqualityComparable concept
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator==(const typename beta_dist<float_t>::param_type &p1,
-                                          const typename beta_dist<float_t>::param_type &p2) {
-    return p1.alpha() == p2.alpha();
+  TRNG_CUDA_ENABLE inline bool operator==(const typename beta_dist<float_t>::param_type &P1,
+                                          const typename beta_dist<float_t>::param_type &P2) {
+    return P1.alpha() == P2.alpha();
   }
 
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator!=(const typename beta_dist<float_t>::param_type &p1,
-                                          const typename beta_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+  TRNG_CUDA_ENABLE inline bool operator!=(const typename beta_dist<float_t>::param_type &P1,
+                                          const typename beta_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -233,12 +231,12 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    beta_dist<float_t> &g) {
-    typename beta_dist<float_t>::param_type p;
+    typename beta_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[beta ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[beta ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/binomial_dist.hpp
+++ b/inst/include/trng/binomial_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -48,32 +48,32 @@ namespace trng {
   // non-uniform random number generator class
   class binomial_dist {
   public:
-    typedef int result_type;
-    class param_type;
+    using result_type = int;
 
     class param_type {
     private:
-      double p_;
-      int n_;
+      double p_{0.5};
+      int n_{0};
       std::vector<double> P_;
 
       void calc_probabilities() {
         P_ = std::vector<double>();
-        double ln_binom = 0.0;
-        const double ln_p = math::ln(p_);
-        const double ln_1_p = math::ln(1.0 - p_);
-        for (int i = 0; i <= n_; ++i) {
-          double ln_prob =
-              ln_binom + static_cast<double>(i) * ln_p + static_cast<double>(n_ - i) * ln_1_p;
+        P_.reserve(n_ + 1);
+        double ln_binom{0.0};
+        const double ln_p{math::ln(p_)};
+        const double ln_1_p{math::ln(1.0 - p_)};
+        for (int i{0}; i <= n_; ++i) {
+          const double ln_prob{ln_binom + static_cast<double>(i) * ln_p +
+                               static_cast<double>(n_ - i) * ln_1_p};
           P_.push_back(math::exp(ln_prob));
           ln_binom += math::ln(static_cast<double>(n_ - i));
           ln_binom -= math::ln(static_cast<double>(i + 1));
         }
         // build list with cumulative density function
-        for (std::vector<double>::size_type i(1); i < P_.size(); ++i)
+        for (std::vector<double>::size_type i{1}; i < P_.size(); ++i)
           P_[i] += P_[i - 1];
         // normailze, just in case of rounding errors
-        for (std::vector<double>::size_type i(0); i < P_.size(); ++i)
+        for (std::vector<double>::size_type i{0}; i < P_.size(); ++i)
           P_[i] /= P_.back();
       }
 
@@ -88,8 +88,8 @@ namespace trng {
         n_ = n_new;
         calc_probabilities();
       }
-      param_type() : p_(0.5), n_(0) {}
-      param_type(double p, int n) : p_(p), n_(n) { calc_probabilities(); }
+      param_type() = default;
+      explicit param_type(double p, int n) : p_(p), n_(n) { calc_probabilities(); }
       friend class binomial_dist;
     };
 
@@ -98,8 +98,8 @@ namespace trng {
 
   public:
     // constructor
-    binomial_dist(double p, int n) : P(p, n) {}
-    explicit binomial_dist(const param_type &P) : P(P) {}
+    explicit binomial_dist(double p, int n) : P{p, n} {}
+    explicit binomial_dist(const param_type &P) : P{P} {}
     // reset internal state
     void reset() {}
     // random numbers
@@ -108,8 +108,8 @@ namespace trng {
       return utility::discrete(utility::uniformoo<double>(r), P.P_.begin(), P.P_.end());
     }
     template<typename R>
-    int operator()(R &r, const param_type &p) {
-      binomial_dist g(p);
+    int operator()(R &r, const param_type &P) {
+      binomial_dist g(P);
       return g(r);
     }
     // property methods
@@ -142,13 +142,13 @@ namespace trng {
   // -------------------------------------------------------------------
 
   // EqualityComparable concept
-  inline bool operator==(const binomial_dist::param_type &p1,
-                         const binomial_dist::param_type &p2) {
-    return p1.p() == p2.p() and p1.n() == p2.n();
+  inline bool operator==(const binomial_dist::param_type &P1,
+                         const binomial_dist::param_type &P2) {
+    return P1.p() == P2.p() and P1.n() == P2.n();
   }
-  inline bool operator!=(const binomial_dist::param_type &p1,
-                         const binomial_dist::param_type &p2) {
-    return not(p1 == p2);
+  inline bool operator!=(const binomial_dist::param_type &P1,
+                         const binomial_dist::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // Streamable concept
@@ -200,12 +200,12 @@ namespace trng {
   template<typename char_t, typename traits_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    binomial_dist &g) {
-    binomial_dist::param_type p;
+    binomial_dist::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[binomial ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[binomial ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/cauchy_dist.hpp
+++ b/inst/include/trng/cauchy_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -51,12 +51,11 @@ namespace trng {
   template<typename float_t = double>
   class cauchy_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type theta_, eta_;
+      result_type theta_{1}, eta_{0};
 
     public:
       TRNG_CUDA_ENABLE
@@ -68,54 +67,54 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void eta(result_type eta_new) { eta_ = eta_new; }
       TRNG_CUDA_ENABLE
-      param_type() : theta_(1), eta_(0) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(result_type theta, result_type eta) : theta_(theta), eta_(eta) {}
+      explicit param_type(result_type theta, result_type eta) : theta_(theta), eta_(eta) {}
 
       friend class cauchy_dist;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1)
-            << p.theta() << ' ' << p.eta() << ')';
+            << P.theta() << ' ' << P.eta() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t theta, eta;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> theta >> utility::delim(' ') >> eta >> utility::delim(')');
         if (in)
-          p = param_type(theta, eta);
+          P = param_type(theta, eta);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
     result_type icdf_(result_type x) const {
-      result_type t = x * math::constants<result_type>::pi();
-      return p.eta() - p.theta() * math::cos(t) / math::sin(t);
+      const result_type t{x * math::constants<result_type>::pi};
+      return P.eta() - P.theta() * math::cos(t) / math::sin(t);
     }
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    cauchy_dist(result_type theta, result_type eta) : p(theta, eta) {}
+    explicit cauchy_dist(result_type theta, result_type eta) : P{theta, eta} {}
     TRNG_CUDA_ENABLE
-    explicit cauchy_dist(const param_type &p) : p(p) {}
+    explicit cauchy_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -125,8 +124,8 @@ namespace trng {
       return icdf_(utility::uniformoo<result_type>(r));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      cauchy_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      cauchy_dist g(P);
       return g(r);
     }
     // property methods
@@ -135,30 +134,30 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &p_new) { P = p_new; }
     TRNG_CUDA_ENABLE
-    result_type theta() const { return p.theta(); }
+    result_type theta() const { return P.theta(); }
     TRNG_CUDA_ENABLE
-    void theta(result_type theta_new) { p.theta(theta_new); }
+    void theta(result_type theta_new) { P.theta(theta_new); }
     TRNG_CUDA_ENABLE
-    result_type eta() const { return p.eta(); }
+    result_type eta() const { return P.eta(); }
     TRNG_CUDA_ENABLE
-    void eta(result_type eta_new) { p.eta(eta_new); }
+    void eta(result_type eta_new) { P.eta(eta_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
-      x -= p.eta();
-      x /= p.theta();
-      return math::constants<result_type>::one_over_pi() / (1.0 + x * x) / p.theta();
+      x -= P.eta();
+      x /= P.theta();
+      return math::constants<result_type>::one_over_pi / (1 + x * x) / P.theta();
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
-      x -= p.eta();
-      x /= p.theta();
-      return math::constants<result_type>::one_over_pi() * math::atan(x) +
+      x -= P.eta();
+      x /= P.theta();
+      return math::constants<result_type>::one_over_pi * math::atan(x) +
              result_type(1) / result_type(2);
     }
     // inverse cumulative density function
@@ -182,15 +181,15 @@ namespace trng {
 
   // EqualityComparable concept
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator==(const typename cauchy_dist<float_t>::param_type &p1,
-                                          const typename cauchy_dist<float_t>::param_type &p2) {
-    return p1.theta() == p2.theta() and p1.eta() == p2.eta();
+  TRNG_CUDA_ENABLE inline bool operator==(const typename cauchy_dist<float_t>::param_type &P1,
+                                          const typename cauchy_dist<float_t>::param_type &P2) {
+    return P1.theta() == P2.theta() and P1.eta() == P2.eta();
   }
 
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator!=(const typename cauchy_dist<float_t>::param_type &p1,
-                                          const typename cauchy_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+  TRNG_CUDA_ENABLE inline bool operator!=(const typename cauchy_dist<float_t>::param_type &P1,
+                                          const typename cauchy_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -222,12 +221,12 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    cauchy_dist<float_t> &g) {
-    typename cauchy_dist<float_t>::param_type p;
+    typename cauchy_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[cauchy ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[cauchy ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/chi_square_dist.hpp
+++ b/inst/include/trng/chi_square_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -51,12 +51,11 @@ namespace trng {
   template<typename float_t = double>
   class chi_square_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      int nu_;
+      int nu_{1};
 
     public:
       TRNG_CUDA_ENABLE
@@ -64,7 +63,7 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void nu(int nu_new) { nu_ = nu_new; }
       TRNG_CUDA_ENABLE
-      param_type() : nu_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
       explicit param_type(int nu) : nu_(nu) {}
 
@@ -73,53 +72,53 @@ namespace trng {
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << p.nu() << ')';
+        out << '(' << P.nu() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         int nu;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> nu >> utility::delim(')');
         if (in)
-          p = param_type(nu);
+          P = param_type(nu);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
     result_type icdf_(result_type x) const {
       if (x <= math::numeric_limits<result_type>::epsilon())
         return 0;
-      const result_type kappa = p.nu() / 2;
-      const result_type theta = 2;
+      const result_type kappa{P.nu() / result_type(2)};
+      const result_type theta{2};
       if (kappa == 1)  // special case of exponential distribution
         return -math::ln(1 - x) * theta;
-      const result_type ln_Gamma_kappa = math::ln_Gamma(kappa);
-      result_type y = kappa, y_old;
+      const result_type ln_Gamma_kappa{math::ln_Gamma(kappa)};
+      result_type y{kappa}, y_old;
       if (kappa < 1 and x < result_type(1) / result_type(2))
         y = x * x;
-      int num_iterations = 0;
+      int num_iterations{0};
       do {
         ++num_iterations;
         y_old = y;
-        result_type f0 = math::GammaP(kappa, y) - x;
-        result_type f1 = math::pow(y, kappa - 1) * math::exp(-y - ln_Gamma_kappa);
-        result_type f2 = f1 * (kappa - 1 - y) / y;
+        const result_type f0{math::GammaP(kappa, y) - x};
+        const result_type f1{math::pow(y, kappa - 1) * math::exp(-y - ln_Gamma_kappa)};
+        const result_type f2{f1 * (kappa - 1 - y) / y};
         y -= f0 / f1 * (1 + f0 * f2 / (2 * f1 * f1));
-      } while (num_iterations < 16 &&
+      } while (num_iterations < 16 and
                math::abs((y - y_old) / y) > 16 * math::numeric_limits<result_type>::epsilon());
       return y * theta;
     }
@@ -127,9 +126,9 @@ namespace trng {
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    explicit chi_square_dist(int nu) : p(nu) {}
+    explicit chi_square_dist(int nu) : P{nu} {}
     TRNG_CUDA_ENABLE
-    explicit chi_square_dist(const param_type &p) : p(p) {}
+    explicit chi_square_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -139,8 +138,8 @@ namespace trng {
       return icdf_(utility::uniformco<result_type>(r));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      chi_square_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      chi_square_dist g(P);
       return g(r);
     }
     // property methods
@@ -149,31 +148,28 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &p_new) { P = p_new; }
     TRNG_CUDA_ENABLE
-    int nu() const { return p.nu(); }
+    int nu() const { return P.nu(); }
     TRNG_CUDA_ENABLE
-    void nu(int nu_new) { p.nu(nu_new); }
+    void nu(int nu_new) { P.nu(nu_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
       if (x < 0)
         return 0;
-      else {
-        x /= 2;
-        return math::pow(x, p.nu() / result_type(2) - 1) /
-               (math::exp(x + math::ln_Gamma(p.nu() / result_type(2))) * 2);
-      }
+      x /= 2;
+      return math::pow(x, P.nu() / result_type(2) - 1) /
+             (math::exp(x + math::ln_Gamma(P.nu() / result_type(2))) * 2);
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
       if (x <= 0)
         return 0;
-      else
-        return math::GammaP(p.nu() / result_type(2), x / 2);
+      return math::GammaP(P.nu() / result_type(2), x / 2);
     }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
@@ -197,16 +193,16 @@ namespace trng {
   // EqualityComparable concept
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator==(
-      const typename chi_square_dist<float_t>::param_type &p1,
-      const typename chi_square_dist<float_t>::param_type &p2) {
-    return p1.nu() == p2.nu();
+      const typename chi_square_dist<float_t>::param_type &P1,
+      const typename chi_square_dist<float_t>::param_type &P2) {
+    return P1.nu() == P2.nu();
   }
 
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator!=(
-      const typename chi_square_dist<float_t>::param_type &p1,
-      const typename chi_square_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+      const typename chi_square_dist<float_t>::param_type &P1,
+      const typename chi_square_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -238,13 +234,13 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    chi_square_dist<float_t> &g) {
-    typename chi_square_dist<float_t>::param_type p;
+    typename chi_square_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[chi_square ") >> p >>
+    in >> utility::ignore_spaces() >> utility::delim("[chi_square ") >> P >>
         utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/constants.hpp
+++ b/inst/include/trng/constants.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,11 +34,7 @@
 
 #define TRNG_CONSTANTS_HPP
 
-#include <trng/cuda.hpp>
-
-#define TRNG_NEW_CONSTANT(type, value, x) \
-  TRNG_CUDA_ENABLE                        \
-  static type x() noexcept { return value; }
+#define TRNG_NEW_CONSTANT(type, value, x) static constexpr type x = value
 
 namespace trng {
 
@@ -62,6 +58,8 @@ namespace trng {
       TRNG_NEW_CONSTANT(float, .707106781186547524400845f, one_over_sqrt_2);
       TRNG_NEW_CONSTANT(float, .398942280401432677939946f, one_over_sqrt_2pi);
       TRNG_NEW_CONSTANT(float, .797884560802865355879892f, sqrt_2_over_pi);
+      TRNG_NEW_CONSTANT(float, .886226925452758013649085f, sqrt_pi_over_2);
+      TRNG_NEW_CONSTANT(float, 1.77245385090551602729817f, sqrt_pi);
     };
 
     template<>
@@ -79,6 +77,8 @@ namespace trng {
       TRNG_NEW_CONSTANT(double, .707106781186547524400845, one_over_sqrt_2);
       TRNG_NEW_CONSTANT(double, .398942280401432677939946, one_over_sqrt_2pi);
       TRNG_NEW_CONSTANT(double, .797884560802865355879892, sqrt_2_over_pi);
+      TRNG_NEW_CONSTANT(double, .886226925452758013649085, sqrt_pi_over_2);
+      TRNG_NEW_CONSTANT(double, 1.77245385090551602729817, sqrt_pi);
     };
 
     template<>
@@ -96,6 +96,8 @@ namespace trng {
       TRNG_NEW_CONSTANT(long double, 0.3183098861837906715377676l, one_over_pi);
       TRNG_NEW_CONSTANT(long double, .398942280401432677939946l, one_over_sqrt_2pi);
       TRNG_NEW_CONSTANT(long double, .797884560802865355879892l, sqrt_2_over_pi);
+      TRNG_NEW_CONSTANT(long double, .886226925452758013649085l, sqrt_pi_over_2);
+      TRNG_NEW_CONSTANT(long double, 1.77245385090551602729817l, sqrt_pi);
     };
 
   }  // namespace math

--- a/inst/include/trng/correlated_normal_dist.hpp
+++ b/inst/include/trng/correlated_normal_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -53,36 +53,34 @@ namespace trng {
   template<typename float_t = double>
   class correlated_normal_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
-      typedef typename std::vector<result_type>::size_type size_type;
+      using size_type = typename std::vector<result_type>::size_type;
       std::vector<result_type> H_;
       size_type d_{0};
 
       void Cholesky_factorization() {
-        for (size_type i = 0; i < d_; ++i) {
-          result_type t;
-          for (size_type k = 0; k < i; ++k) {
-            t = 0.0;
-            for (size_type j = 0; j < k; ++j)
+        for (size_type i{0}; i < d_; ++i) {
+          for (size_type k{0}; k < i; ++k) {
+            result_type t{0};
+            for (size_type j{0}; j < k; ++j)
               t += H_[i * d_ + j] * H_[k * d_ + j];
             H_[i * d_ + k] = (H_[i * d_ + k] - t) / H_[k * d_ + k];
           }
-          t = 0.0;
-          for (size_type j = 0; j < i; ++j)
+          result_type t{0};
+          for (size_type j{0}; j < i; ++j)
             t += H_[i * d_ + j] * H_[i * d_ + j];
           H_[i * d_ + i] = trng::math::sqrt(H_[i * d_ + i] - t);
-          for (size_type k = i + 1; k < d_; ++k)
+          for (size_type k{i + 1}; k < d_; ++k)
             H_[i * d_ + k] = 0;
         }
       }
 
       result_type H_times(const std::vector<result_type> &normal) {
         size_type d(normal.size());
-        result_type y = 0.0;
-        for (size_type j = 0; j < d; ++j)
+        result_type y{0};
+        for (size_type j{0}; j < d; ++j)
           y += H_[(d - 1) * d_ + j] * normal[j];
         return y;
       }
@@ -96,7 +94,7 @@ namespace trng {
         d_ = static_cast<size_type>(
             trng::math::sqrt(static_cast<result_type>(std::distance(first, last))));
         H_.reserve(d_ * d_);
-        for (size_type i = 0; i < d_ * d_; ++i, ++first)
+        for (size_type i{0}; i < d_ * d_; ++i, ++first)
           H_.push_back(*first);
         Cholesky_factorization();
       }
@@ -104,24 +102,24 @@ namespace trng {
       friend class correlated_normal_dist;
 
       // EqualityComparable concept
-      friend inline bool operator==(const typename correlated_normal_dist::param_type &p1,
-                                    const typename correlated_normal_dist::param_type &p2) {
-        return p1.H_ == p2.H_;
+      friend inline bool operator==(const typename correlated_normal_dist::param_type &P1,
+                                    const typename correlated_normal_dist::param_type &P2) {
+        return P1.H_ == P2.H_;
       }
-      friend inline bool operator!=(const typename correlated_normal_dist::param_type &p1,
-                                    const typename correlated_normal_dist::param_type &p2) {
-        return not(p1 == p2);
+      friend inline bool operator!=(const typename correlated_normal_dist::param_type &P1,
+                                    const typename correlated_normal_dist::param_type &P2) {
+        return not(P1 == P2);
       }
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << p.d_ << std::setprecision(17);
-        for (unsigned int i = 0; i < p.d_ * p.d_; ++i)
-          out << ' ' << p.H_[i];
+        out << '(' << P.d_ << std::setprecision(17);
+        for (unsigned int i{0}; i < P.d_ * P.d_; ++i)
+          out << ' ' << P.H_[i];
         out << ')';
         out.flags(flags);
         return out;
@@ -129,21 +127,22 @@ namespace trng {
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
-        std::vector<result_type> H;
-        unsigned int d;
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
+        unsigned int d;
+        std::vector<result_type> H;
         in >> utility::delim('(') >> d;
-        for (unsigned int i = 0; i < d * d; ++i) {
-          result_type t = 0;
+        H.reserve(d * d);
+        for (unsigned int i{0}; i < d * d; ++i) {
+          result_type t{0};
           in >> utility::delim(' ') >> t;
           H.push_back(t);
         }
         in >> utility::delim(')');
         if (in) {
-          p.d_ = d;
-          p.H_ = H;
+          P.d_ = d;
+          P.H_ = H;
         }
         in.flags(flags);
         return in;
@@ -151,35 +150,35 @@ namespace trng {
     };
 
   private:
-    param_type p;
+    param_type P;
     std::vector<result_type> normal;
 
   public:
     // constructor
     template<typename iter>
-    correlated_normal_dist(iter first, iter last) : p(first, last) {}
-    explicit correlated_normal_dist(const param_type &p) : p(p) {}
+    explicit correlated_normal_dist(iter first, iter last) : P{first, last} {}
+    explicit correlated_normal_dist(const param_type &P) : P{P} {}
     // reset internal state
     void reset() { normal.clear(); }
     // random numbers
     template<typename R>
     result_type operator()(R &r) {
       normal.push_back(trng::math::inv_Phi(utility::uniformoo<result_type>(r)));
-      result_type y = p.H_times(normal);
-      if (normal.size() == p.d())
+      result_type y{P.H_times(normal)};
+      if (normal.size() == P.d())
         normal.clear();
       return y;
     }
     template<typename R>
-    result_type operator()(R &r, const param_type &p) {
-      correlated_normal_dist g(p);
+    result_type operator()(R &r, const param_type &P) {
+      correlated_normal_dist g(P);
       return g(r);
     }
     // property methods
     result_type min() const { return -math::numeric_limits<result_type>::infinity(); }
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
-    param_type param() const { return p; }
-    void param(const param_type &p_new) { p = p_new; }
+    param_type param() const { return P; }
+    void param(const param_type &P_new) { P = P_new; }
   };
 
   // -------------------------------------------------------------------
@@ -210,13 +209,13 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    correlated_normal_dist<float_t> &g) {
-    typename correlated_normal_dist<float_t>::param_type p;
+    typename correlated_normal_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[correlated_normal ") >> p >>
+    in >> utility::ignore_spaces() >> utility::delim("[correlated_normal ") >> P >>
         utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/cuda.hpp
+++ b/inst/include/trng/cuda.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/inst/include/trng/discrete_dist.hpp
+++ b/inst/include/trng/discrete_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -36,7 +36,7 @@
 
 #include <trng/limits.hpp>
 #include <trng/utility.hpp>
-#include <trng/math.hpp>
+#include <trng/int_math.hpp>
 #include <ostream>
 #include <iomanip>
 #include <istream>
@@ -50,54 +50,49 @@ namespace trng {
   // non-uniform random number generator class
   class discrete_dist {
   public:
-    typedef int result_type;
-    class param_type;
+    using result_type = int;
 
     class param_type {
     private:
-      typedef std::vector<double>::size_type size_type;
-      std::vector<double> P;
-      size_type N, offset, layers;
+      using size_type = std::vector<double>::size_type;
+      std::vector<double> P_;
+      size_type N_{0}, layers_{0}, offset_{0};
+
+      explicit param_type(std::vector<double> P)
+          : P_(std::move(P)),
+            N_{P_.size()},
+            layers_{int_math::log2_ceil(N_)},
+            offset_{int_math::pow2(layers_) - 1} {
+        P_.resize(N_ + offset_);
+        std::copy_backward(P_.begin(), P_.begin() + N_, P_.end());
+        std::fill(P_.begin(), P_.begin() + offset_, 0);
+        update_all_layers();
+      }
 
     public:
-      param_type() : P(), N(0), offset(0), layers(0) {}
+      param_type() = default;
       template<typename iter>
-      param_type(iter first, iter last) : P(first, last) {
-        N = P.size();
-        layers = math::log2_ceil(N);
-        offset = math::pow2(layers) - 1;
-        P.resize(N + offset);
-        std::copy_backward(P.begin(), P.begin() + N, P.end());
-        std::fill(P.begin(), P.begin() + offset, 0);
-        update_all_layers();
-      }
-      explicit param_type(int n) : P(n, 1.0) {
-        N = P.size();
-        layers = math::log2_ceil(N);
-        offset = math::pow2(layers) - 1;
-        P.resize(N + offset);
-        std::copy_backward(P.begin(), P.begin() + N, P.end());
-        std::fill(P.begin(), P.begin() + offset, 0);
-        update_all_layers();
-      }
+      explicit param_type(iter first, iter last)
+          : param_type{std::vector<double>(first, last)} {}
+      explicit param_type(int n) : param_type{std::vector<double>(n, 1.0)} {}
 
     private:
       void update_layer(size_type layer, size_type n) {
-        size_type first = math::pow2(layer) - 1, last = first + n;
-        for (size_type i = first; i < last; ++i, ++i)
+        const size_type first{int_math::pow2(layer) - 1}, last{first + n};
+        for (size_type i{first}; i < last; ++i, ++i)
           if (i + 1 < last)
-            P[(i - 1) / 2] = P[i] + P[i + 1];
+            P_[(i - 1) / 2] = P_[i] + P_[i + 1];
           else
-            P[(i - 1) / 2] = P[i];
+            P_[(i - 1) / 2] = P_[i];
       }
       void update_all_layers() {
-        size_type layer = layers;
+        size_type layer = layers_;
         if (layer > 0) {
-          update_layer(layer, N);
+          update_layer(layer, N_);
           --layer;
         }
         while (layer > 0) {
-          update_layer(layer, math::pow2(layer));
+          update_layer(layer, int_math::pow2(layer));
           --layer;
         }
       }
@@ -120,26 +115,26 @@ namespace trng {
     // constructor
     template<typename iter>
     discrete_dist(iter first, iter last) : P(first, last) {}
-    explicit discrete_dist(int N) : P(N) {}
-    explicit discrete_dist(const param_type &P) : P(P) {}
+    explicit discrete_dist(int N) : P{N} {}
+    explicit discrete_dist(const param_type &P) : P{P} {}
     // reset internal state
     void reset() {}
     // random numbers
     template<typename R>
     int operator()(R &r) {
-      if (P.N == 0)
+      if (P.N_ == 0)
         return -1;
-      double u(utility::uniformco<double>(r) * P.P[0]);
-      param_type::size_type x(0);
-      while (x < P.offset) {
-        if (u < P.P[2 * x + 1]) {
+      double u(utility::uniformco<double>(r) * P.P_[0]);
+      param_type::size_type x{0};
+      while (x < P.offset_) {
+        if (u < P.P_[2 * x + 1]) {
           x = 2 * x + 1;
         } else {
-          u -= P.P[2 * x + 1];
+          u -= P.P_[2 * x + 1];
           x = 2 * x + 2;
         }
       }
-      return static_cast<int>(x - P.offset);
+      return static_cast<int>(x - P.offset_);
     }
     template<typename R>
     int operator()(R &r, const param_type &p) {
@@ -148,29 +143,29 @@ namespace trng {
     }
     // property methods
     int min() const { return 0; }
-    int max() const { return static_cast<int>(P.N - 1); }
+    int max() const { return static_cast<int>(P.N_ - 1); }
     param_type param() const { return P; }
     void param(const param_type &P_new) { P = P_new; }
     void param(int x, double p) {
-      x += static_cast<int>(P.offset);
-      P.P[x] = p;
+      x += static_cast<int>(P.offset_);
+      P.P_[x] = p;
       if (x > 0) {
         do {
           x = (x - 1) / 2;
-          P.P[x] = P.P[2 * x + 1] + P.P[2 * x + 2];
+          P.P_[x] = P.P_[2 * x + 1] + P.P_[2 * x + 2];
         } while (x > 0);
       }
     }
     // probability density function
     double pdf(int x) const {
-      return (x < 0 or x >= static_cast<int>(P.N)) ? 0.0 : P.P[x + P.offset] / P.P[0];
+      return (x < 0 or x >= static_cast<int>(P.N_)) ? 0.0 : P.P_[x + P.offset_] / P.P_[0];
     }
     // cumulative density function
     double cdf(int x) const {
       if (x < 0)
         return 0.0;
-      if (x < static_cast<int>(P.N))
-        return std::accumulate(&P.P[P.offset], &P.P[x + P.offset + 1], 0.0) / P.P[0];
+      if (x < static_cast<int>(P.N_))
+        return std::accumulate(&P.P_[P.offset_], &P.P_[x + P.offset_ + 1], 0.0) / P.P_[0];
       return 1.0;
     }
   };
@@ -178,13 +173,13 @@ namespace trng {
   // -------------------------------------------------------------------
 
   // EqualityComparable concept
-  inline bool operator==(const discrete_dist::param_type &p1,
-                         const discrete_dist::param_type &p2) {
-    return p1.P == p2.P;
+  inline bool operator==(const discrete_dist::param_type &P1,
+                         const discrete_dist::param_type &P2) {
+    return P1.P_ == P2.P_;
   }
-  inline bool operator!=(const discrete_dist::param_type &p1,
-                         const discrete_dist::param_type &p2) {
-    return !(p1 == p2);
+  inline bool operator!=(const discrete_dist::param_type &P1,
+                         const discrete_dist::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // Streamable concept
@@ -193,10 +188,10 @@ namespace trng {
                                                    const discrete_dist::param_type &P) {
     std::ios_base::fmtflags flags(out.flags());
     out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    out << '(' << P.N << ' ';
-    for (std::vector<double>::size_type i = P.offset; i < P.P.size(); ++i) {
-      out << std::setprecision(17) << P.P[i];
-      if (i + 1 < P.P.size())
+    out << '(' << P.N_ << ' ';
+    for (std::vector<double>::size_type i{P.offset_}; i < P.P_.size(); ++i) {
+      out << std::setprecision(17) << P.P_[i];
+      if (i + 1 < P.P_.size())
         out << ' ';
     }
     out << ')';
@@ -213,7 +208,7 @@ namespace trng {
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
     in >> utility::delim('(') >> n >> utility::delim(' ');
-    for (std::vector<double>::size_type i = 0; i < n; ++i) {
+    for (std::vector<double>::size_type i{0}; i < n; ++i) {
       in >> p;
       if (i + 1 < n)
         in >> utility::delim(' ');
@@ -250,12 +245,12 @@ namespace trng {
   template<typename char_t, typename traits_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    discrete_dist &g) {
-    discrete_dist::param_type p;
+    discrete_dist::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[discrete ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[discrete ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/exponential_dist.hpp
+++ b/inst/include/trng/exponential_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -50,12 +50,11 @@ namespace trng {
   template<typename float_t = double>
   class exponential_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type mu_;
+      result_type mu_{1};
 
     public:
       TRNG_CUDA_ENABLE
@@ -63,7 +62,7 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void mu(result_type mu_new) { mu_ = mu_new; }
       TRNG_CUDA_ENABLE
-      param_type() : mu_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
       explicit param_type(result_type mu) : mu_(mu) {}
 
@@ -72,10 +71,10 @@ namespace trng {
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << p.mu()
+        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << P.mu()
             << ')';
         out.flags(flags);
         return out;
@@ -83,38 +82,38 @@ namespace trng {
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t mu;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> mu >> utility::delim(')');
         if (in)
-          p = param_type(mu);
+          P = param_type(mu);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    explicit exponential_dist(result_type mu) : p(mu) {}
+    explicit exponential_dist(result_type mu) : P{mu} {}
     TRNG_CUDA_ENABLE
-    explicit exponential_dist(const param_type &p) : p(p) {}
+    explicit exponential_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
     // random numbers
     template<typename R>
     TRNG_CUDA_ENABLE result_type operator()(R &r) {
-      return -p.mu() * math::ln(utility::uniformoc<result_type>(r));
+      return -P.mu() * math::ln(utility::uniformoc<result_type>(r));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      exponential_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      exponential_dist g(P);
       return g(r);
     }
     // property methods
@@ -123,19 +122,19 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &P_new) { P = P_new; }
     TRNG_CUDA_ENABLE
-    result_type mu() const { return p.mu(); }
+    result_type mu() const { return P.mu(); }
     TRNG_CUDA_ENABLE
-    void mu(result_type mu_new) { p.mu(mu_new); }
+    void mu(result_type mu_new) { P.mu(mu_new); }
     // probability density function
     TRNG_CUDA_ENABLE
-    result_type pdf(result_type x) const { return x < 0 ? 0 : math::exp(-x / p.mu()) / p.mu(); }
+    result_type pdf(result_type x) const { return x < 0 ? 0 : math::exp(-x / P.mu()) / P.mu(); }
     // cumulative density function
     TRNG_CUDA_ENABLE
-    result_type cdf(result_type x) const { return x <= 0 ? 0 : 1 - math::exp(-x / p.mu()); }
+    result_type cdf(result_type x) const { return x <= 0 ? 0 : 1 - math::exp(-x / P.mu()); }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
     result_type icdf(result_type x) const {
@@ -147,7 +146,7 @@ namespace trng {
       }
       if (x == 1)
         return math::numeric_limits<result_type>::infinity();
-      return -p.mu() * math::ln(1 - x);
+      return -P.mu() * math::ln(1 - x);
     }
   };
 
@@ -156,16 +155,16 @@ namespace trng {
   // EqualityComparable concept
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator==(
-      const typename exponential_dist<float_t>::param_type &p1,
-      const typename exponential_dist<float_t>::param_type &p2) {
-    return p1.mu() == p2.mu();
+      const typename exponential_dist<float_t>::param_type &P1,
+      const typename exponential_dist<float_t>::param_type &P2) {
+    return P1.mu() == P2.mu();
   }
 
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator!=(
-      const typename exponential_dist<float_t>::param_type &p1,
-      const typename exponential_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+      const typename exponential_dist<float_t>::param_type &P1,
+      const typename exponential_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -197,13 +196,13 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    exponential_dist<float_t> &g) {
-    typename exponential_dist<float_t>::param_type p;
+    typename exponential_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[exponential ") >> p >>
+    in >> utility::ignore_spaces() >> utility::delim("[exponential ") >> P >>
         utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/extreme_value_dist.hpp
+++ b/inst/include/trng/extreme_value_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -50,12 +50,11 @@ namespace trng {
   template<typename float_t = double>
   class extreme_value_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type theta_, eta_;
+      result_type theta_{1}, eta_{0};
 
     public:
       TRNG_CUDA_ENABLE
@@ -67,58 +66,58 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void eta(result_type eta_new) { eta_ = eta_new; }
       TRNG_CUDA_ENABLE
-      param_type() : theta_(1), eta_(0) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(result_type theta, result_type eta) : theta_(theta), eta_(eta) {}
+      explicit param_type(result_type theta, result_type eta) : theta_{theta}, eta_{eta} {}
 
       friend class extreme_value_dist;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1)
-            << p.theta() << ' ' << p.eta() << ')';
+            << P.theta() << ' ' << P.eta() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t theta, eta;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> theta >> utility::delim(' ') >> eta >> utility::delim(')');
         if (in)
-          p = param_type(theta, eta);
+          P = param_type(theta, eta);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    extreme_value_dist(result_type theta, result_type eta) : p(theta, eta) {}
+    explicit extreme_value_dist(result_type theta, result_type eta) : P{theta, eta} {}
     TRNG_CUDA_ENABLE
-    explicit extreme_value_dist(const param_type &p) : p(p) {}
+    explicit extreme_value_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
     // random numbers
     template<typename R>
     TRNG_CUDA_ENABLE result_type operator()(R &r) {
-      return p.eta() + p.theta() * math::ln(-math::ln(utility::uniformoo<result_type>(r)));
+      return P.eta() + P.theta() * math::ln(-math::ln(utility::uniformoo<result_type>(r)));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      extreme_value_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      extreme_value_dist g(P);
       return g(r);
     }
     // property methods
@@ -127,29 +126,29 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &P_new) { P = P_new; }
     TRNG_CUDA_ENABLE
-    result_type theta() const { return p.theta(); }
+    result_type theta() const { return P.theta(); }
     TRNG_CUDA_ENABLE
-    void theta(result_type theta_new) { p.theta(theta_new); }
+    void theta(result_type theta_new) { P.theta(theta_new); }
     TRNG_CUDA_ENABLE
-    result_type eta() const { return p.eta(); }
+    result_type eta() const { return P.eta(); }
     TRNG_CUDA_ENABLE
-    void eta(result_type eta_new) { p.eta(eta_new); }
+    void eta(result_type eta_new) { P.eta(eta_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
-      x -= p.eta();
-      x /= p.theta();
-      return math::exp(x - math::exp(x)) / p.theta();
+      x -= P.eta();
+      x /= P.theta();
+      return math::exp(x - math::exp(x)) / P.theta();
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
-      x -= p.eta();
-      x /= p.theta();
+      x -= P.eta();
+      x /= P.theta();
       return 1 - math::exp(-math::exp(x));
     }
     // inverse cumulative density function
@@ -165,7 +164,7 @@ namespace trng {
         return -math::numeric_limits<result_type>::infinity();
       if (x == 1)
         return math::numeric_limits<result_type>::infinity();
-      return p.eta() + p.theta() * math::ln(-math::ln(1 - x));
+      return P.eta() + P.theta() * math::ln(-math::ln(1 - x));
     }
   };
 
@@ -174,16 +173,16 @@ namespace trng {
   // EqualityComparable concept
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator==(
-      const typename extreme_value_dist<float_t>::param_type &p1,
-      const typename extreme_value_dist<float_t>::param_type &p2) {
-    return p1.theta() == p2.theta() and p1.eta() == p2.eta();
+      const typename extreme_value_dist<float_t>::param_type &P1,
+      const typename extreme_value_dist<float_t>::param_type &P2) {
+    return P1.theta() == P2.theta() and P1.eta() == P2.eta();
   }
 
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator!=(
-      const typename extreme_value_dist<float_t>::param_type &p1,
-      const typename extreme_value_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+      const typename extreme_value_dist<float_t>::param_type &P1,
+      const typename extreme_value_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -215,13 +214,13 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    extreme_value_dist<float_t> &g) {
-    typename extreme_value_dist<float_t>::param_type p;
+    typename extreme_value_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[extreme_value ") >> p >>
+    in >> utility::ignore_spaces() >> utility::delim("[extreme_value ") >> P >>
         utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/fast_discrete_dist.hpp
+++ b/inst/include/trng/fast_discrete_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -57,37 +57,25 @@ namespace trng {
   // non-uniform random number generator class
   class fast_discrete_dist {
   public:
-    typedef int result_type;
-    class param_type;
+    using result_type = int;
 
     class param_type {
     private:
-      typedef std::vector<double>::size_type size_type;
+      using size_type = std::vector<double>::size_type;
       std::vector<double> P, F;
       std::vector<int> L;
       size_type N{0};
 
-    public:
-      param_type() = default;
-      template<typename iter>
-      param_type(iter first, iter last)
-          : P(first, last), F(P.size()), L(P.size()), N(P.size()) {
-        update();
-      }
-      explicit param_type(int n) : P(n, 1.0), F(P.size()), L(P.size()), N(P.size()) {
-        update();
-      }
-
-    private:
-      void update() {
-        double s = std::accumulate(P.begin(), P.end(), 0.0);
+      explicit param_type(std::vector<double> P)
+          : P(std::move(P)), F(P.size()), L(P.size()), N(P.size()) {
+        const double s{std::accumulate(P.begin(), P.end(), 0.0)};
         if (s > 0.0) {
-          for (int i = 0; i < P.size(); ++i)
-            P[i] /= s;
+          for (auto &val : P)
+            val /= s;
           std::vector<int> G, S;
           G.reserve(N);
           S.reserve(N);
-          for (int i = 0; i < F.size(); ++i) {
+          for (int i{0}; i < F.size(); ++i) {
             F[i] = N * P[i];
             if (F[i] < 1.0)
               S.push_back(i);
@@ -95,7 +83,7 @@ namespace trng {
               G.push_back(i);
           }
           while ((not S.empty()) and (not G.empty())) {
-            int k = G.back(), j = S.back();
+            const int k{G.back()}, j{S.back()};
             L[j] = k;
             F[k] -= 1.0 - F[j];
             S.pop_back();
@@ -108,6 +96,12 @@ namespace trng {
       }
 
     public:
+      param_type() = default;
+      template<typename iter>
+      explicit param_type(iter first, iter last)
+          : param_type{std::vector<double>(first, last)} {}
+      explicit param_type(int n) : param_type{std::vector<double>(n, 1.0)} {}
+
       friend class fast_discrete_dist;
       friend bool operator==(const param_type &, const param_type &);
       template<typename char_t, typename traits_t>
@@ -124,21 +118,21 @@ namespace trng {
   public:
     // constructor
     template<typename iter>
-    fast_discrete_dist(iter first, iter last) : P(first, last) {}
-    explicit fast_discrete_dist(int N) : P(N) {}
-    explicit fast_discrete_dist(const param_type &P) : P(P) {}
+    explicit fast_discrete_dist(iter first, iter last) : P{first, last} {}
+    explicit fast_discrete_dist(int N) : P{N} {}
+    explicit fast_discrete_dist(const param_type &P) : P{P} {}
     // reset internal state
     void reset() {}
     // random numbers
     template<typename R>
     int operator()(R &r) {
-      double U = utility::uniformco<double>(r) * P.N;
-      int I = static_cast<int>(U);
+      const double U{utility::uniformco<double>(r) * P.N};
+      const int I{static_cast<int>(U)};
       return U - I <= P.F[I] ? I : P.L[I];
     }
     template<typename R>
-    int operator()(R &r, const param_type &p) {
-      fast_discrete_dist g(p);
+    int operator()(R &r, const param_type &P) {
+      fast_discrete_dist g(P);
       return g(r);
     }
     // property methods
@@ -156,18 +150,18 @@ namespace trng {
         return std::accumulate(P.P.begin(), P.P.begin() + x + 1, 0.0);
       return 1.0;
     }
-  };
+  };  // namespace trng
 
   // -------------------------------------------------------------------
 
   // EqualityComparable concept
-  inline bool operator==(const fast_discrete_dist::param_type &p1,
-                         const fast_discrete_dist::param_type &p2) {
-    return p1.P == p2.P;
+  inline bool operator==(const fast_discrete_dist::param_type &P1,
+                         const fast_discrete_dist::param_type &P2) {
+    return P1.P == P2.P;
   }
-  inline bool operator!=(const fast_discrete_dist::param_type &p1,
-                         const fast_discrete_dist::param_type &p2) {
-    return !(p1 == p2);
+  inline bool operator!=(const fast_discrete_dist::param_type &P1,
+                         const fast_discrete_dist::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // Streamable concept
@@ -196,7 +190,7 @@ namespace trng {
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
     in >> utility::delim('(') >> n >> utility::delim(' ');
-    for (std::vector<double>::size_type i = 0; i < n; ++i) {
+    for (std::vector<double>::size_type i{0}; i < n; ++i) {
       in >> p;
       if (i + 1 < n)
         in >> utility::delim(' ');
@@ -233,13 +227,13 @@ namespace trng {
   template<typename char_t, typename traits_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    fast_discrete_dist &g) {
-    fast_discrete_dist::param_type p;
+    fast_discrete_dist::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[fast_discrete ") >> p >>
+    in >> utility::ignore_spaces() >> utility::delim("[fast_discrete ") >> P >>
         utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/gamma_dist.hpp
+++ b/inst/include/trng/gamma_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -51,12 +51,11 @@ namespace trng {
   template<typename float_t = double>
   class gamma_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type kappa_, theta_;
+      result_type kappa_{1}, theta_{1};
 
     public:
       TRNG_CUDA_ENABLE
@@ -68,7 +67,7 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void theta(result_type theta_new) { theta_ = theta_new; }
       TRNG_CUDA_ENABLE
-      param_type() : kappa_(1), theta_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
       explicit param_type(result_type kappa, result_type theta)
           : kappa_(kappa), theta_(theta) {}
@@ -78,61 +77,61 @@ namespace trng {
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         out << '(' << std::setprecision(math::numeric_limits<result_type>::digits10 + 1)
-            << p.kappa() << ' ' << p.theta() << ')';
+            << P.kappa() << ' ' << P.theta() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t kappa, theta;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> kappa >> utility::delim(' ') >> theta >>
             utility::delim(')');
         if (in)
-          p = param_type(kappa, theta);
+          P = param_type(kappa, theta);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
     result_type icdf_(result_type x) const {
       if (x <= math::numeric_limits<result_type>::epsilon())
         return 0;
-      if (p.kappa() == 1)  // special case of exponential distribution
-        return -math::ln(1 - x) * p.theta();
-      result_type ln_Gamma_kappa = math::ln_Gamma(p.kappa());
-      result_type y = p.kappa(), y_old;
-      int num_iterations = 0;
+      if (P.kappa() == 1)  // special case of exponential distribution
+        return -math::ln(1 - x) * P.theta();
+      const result_type ln_Gamma_kappa{math::ln_Gamma(P.kappa())};
+      result_type y{P.kappa()}, y_old;
+      int num_iterations{0};
       do {
         ++num_iterations;
         y_old = y;
-        result_type f0 = math::GammaP(p.kappa(), y) - x;
-        result_type f1 = math::exp((p.kappa() - 1) * math::ln(y) - y - ln_Gamma_kappa);
-        result_type f2 = f1 * (p.kappa() - 1 - y) / y;
+        const result_type f0{math::GammaP(P.kappa(), y) - x};
+        const result_type f1{math::exp((P.kappa() - 1) * math::ln(y) - y - ln_Gamma_kappa)};
+        const result_type f2{f1 * (P.kappa() - 1 - y) / y};
         y -= f0 / f1 * (1 + f0 * f2 / (2 * f1 * f1));
       } while (num_iterations < 16 &&
                math::abs((y - y_old) / y) > 16 * math::numeric_limits<result_type>::epsilon());
-      return y * p.theta();
+      return y * P.theta();
     }
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    gamma_dist(result_type kappa, result_type theta) : p(kappa, theta) {}
+    explicit gamma_dist(result_type kappa, result_type theta) : P{kappa, theta} {}
     TRNG_CUDA_ENABLE
-    explicit gamma_dist(const param_type &p) : p(p) {}
+    explicit gamma_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -152,35 +151,32 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &P_new) { P = P_new; }
     TRNG_CUDA_ENABLE
-    result_type kappa() const { return p.kappa(); }
+    result_type kappa() const { return P.kappa(); }
     TRNG_CUDA_ENABLE
-    void kappa(result_type kappa_new) { p.kappa(kappa_new); }
+    void kappa(result_type kappa_new) { P.kappa(kappa_new); }
     TRNG_CUDA_ENABLE
-    result_type theta() const { return p.theta(); }
+    result_type theta() const { return P.theta(); }
     TRNG_CUDA_ENABLE
-    void theta(result_type theta_new) { p.theta(theta_new); }
+    void theta(result_type theta_new) { P.theta(theta_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
       if (x < 0)
         return 0;
-      else {
-        x /= p.theta();
-        return math::exp((p.kappa() - 1) * math::ln(x) - x - math::ln_Gamma(p.kappa())) /
-               (p.theta());
-      }
+      x /= P.theta();
+      return math::exp((P.kappa() - 1) * math::ln(x) - x - math::ln_Gamma(P.kappa())) /
+             (P.theta());
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
       if (x <= 0)
         return 0;
-      else
-        return math::GammaP(p.kappa(), x / p.theta());
+      return math::GammaP(P.kappa(), x / P.theta());
     }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
@@ -203,15 +199,15 @@ namespace trng {
 
   // EqualityComparable concept
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator==(const typename gamma_dist<float_t>::param_type &p1,
-                                          const typename gamma_dist<float_t>::param_type &p2) {
-    return p1.kappa() == p2.kappa() and p1.theta() == p2.theta();
+  TRNG_CUDA_ENABLE inline bool operator==(const typename gamma_dist<float_t>::param_type &P1,
+                                          const typename gamma_dist<float_t>::param_type &P2) {
+    return P1.kappa() == P2.kappa() and P1.theta() == P2.theta();
   }
 
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator!=(const typename gamma_dist<float_t>::param_type &p1,
-                                          const typename gamma_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+  TRNG_CUDA_ENABLE inline bool operator!=(const typename gamma_dist<float_t>::param_type &P1,
+                                          const typename gamma_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -243,12 +239,12 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    gamma_dist<float_t> &g) {
-    typename gamma_dist<float_t>::param_type p;
+    typename gamma_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[gamma ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[gamma ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/generate_canonical.hpp
+++ b/inst/include/trng/generate_canonical.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,6 +34,7 @@
 
 #define TRNG_GENERATE_CANONICAL_HPP
 
+#include <type_traits>
 #include <trng/cuda.hpp>
 #include <trng/limits.hpp>
 #include <trng/math.hpp>
@@ -46,33 +47,18 @@ namespace trng {
 
   namespace detail {
 
-    template<typename result_type, typename R, typename category>
-    result_type generate_canonical_impl(R &, result_type, category);
-
-    class integer_tag {};
-    class float_tag {};
-
-    template<bool>
-    struct integer_float_traits;
-
-    template<>
-    struct integer_float_traits<false> {
-      typedef float_tag cat;
-    };
-
-    template<>
-    struct integer_float_traits<true> {
-      typedef integer_tag cat;
-    };
-
     template<typename result_type, typename R>
-    TRNG_CUDA_ENABLE inline result_type generate_canonical_impl(R &r, result_type, float_tag) {
+    TRNG_CUDA_ENABLE inline
+        typename std::enable_if<std::is_floating_point<result_type>::value, result_type>::type
+        generate_canonical_impl(R &r, result_type) {
       return utility::uniformoo<result_type>(r);
     }
 
     template<typename result_type, typename R>
-    TRNG_CUDA_ENABLE inline result_type generate_canonical_impl(R &r, result_type,
-                                                                integer_tag) {
+    TRNG_CUDA_ENABLE inline
+        typename std::enable_if<math::numeric_limits<result_type>::is_integer,
+                                result_type>::type
+        generate_canonical_impl(R &r, result_type) {
       return static_cast<result_type>(
           math::floor(utility::uniformco<double>(r) *
                       (static_cast<double>(R::max) - static_cast<double>(R::min) + 1.0)));
@@ -82,10 +68,7 @@ namespace trng {
 
   template<typename result_type, typename R>
   TRNG_CUDA_ENABLE result_type generate_canonical(R &g) {
-    return detail::generate_canonical_impl(
-        g, result_type(),
-        typename detail::integer_float_traits<
-            math::numeric_limits<result_type>::is_integer>::cat());
+    return detail::generate_canonical_impl(g, result_type());
   }
 
 }  // namespace trng

--- a/inst/include/trng/geometric_dist.hpp
+++ b/inst/include/trng/geometric_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -49,8 +49,7 @@ namespace trng {
   // non-uniform random number generator class
   class geometric_dist {
   public:
-    typedef int result_type;
-    class param_type;
+    using result_type = int;
 
     class param_type {
     private:
@@ -72,7 +71,7 @@ namespace trng {
       }
       TRNG_CUDA_ENABLE
       explicit param_type(double p = 0.5)
-          : p_(p), q_(1.0 - p_), one_over_ln_q_(1.0 / math::ln(q_)) {}
+          : p_{p}, q_{1.0 - p_}, one_over_ln_q_{(1.0 / math::ln(q_))} {}
       friend class geometric_dist;
     };
 
@@ -82,9 +81,9 @@ namespace trng {
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    explicit geometric_dist(double p) : P(p) {}
+    explicit geometric_dist(double p) : P{p} {}
     TRNG_CUDA_ENABLE
-    explicit geometric_dist(const param_type &P) : P(P) {}
+    explicit geometric_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -127,15 +126,15 @@ namespace trng {
 
   // EqualityComparable concept
   TRNG_CUDA_ENABLE
-  inline bool operator==(const geometric_dist::param_type &p1,
-                         const geometric_dist::param_type &p2) {
-    return p1.p() == p2.p();
+  inline bool operator==(const geometric_dist::param_type &P1,
+                         const geometric_dist::param_type &P2) {
+    return P1.p() == P2.p();
   }
 
   TRNG_CUDA_ENABLE
-  inline bool operator!=(const geometric_dist::param_type &p1,
-                         const geometric_dist::param_type &p2) {
-    return !(p1 == p2);
+  inline bool operator!=(const geometric_dist::param_type &P1,
+                         const geometric_dist::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // Streamable concept
@@ -189,12 +188,12 @@ namespace trng {
   template<typename char_t, typename traits_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    geometric_dist &g) {
-    geometric_dist::param_type p;
+    geometric_dist::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[geometric ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[geometric ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/hypergeometric_dist.hpp
+++ b/inst/include/trng/hypergeometric_dist.hpp
@@ -50,8 +50,7 @@ namespace trng {
   // non-uniform random number generator class
   class hypergeometric_dist {
   public:
-    typedef int result_type;
-    class param_type;
+    using result_type = int;
 
     class param_type {
     private:
@@ -65,14 +64,14 @@ namespace trng {
         x_min = std::max(0, d_ - n_ + m_);
         x_max = std::min(d_, m_);
         P_ = std::vector<double>();
-        for (int x = x_min; x <= x_max; ++x)
+        for (int x{x_min}; x <= x_max; ++x)
           P_.push_back(math::exp(
               math::ln_binomial(static_cast<double>(m_), static_cast<double>(x)) +
               math::ln_binomial(static_cast<double>(n_ - m_), static_cast<double>(m_ - x))));
         // build list with cumulative density function
-        for (std::vector<double>::size_type i(1); i < P_.size(); ++i)
+        for (std::vector<double>::size_type i{1}; i < P_.size(); ++i)
           P_[i] += P_[i - 1];
-        for (std::vector<double>::size_type i(0); i < P_.size(); ++i)
+        for (std::vector<double>::size_type i{0}; i < P_.size(); ++i)
           P_[i] /= P_.back();
       }
 
@@ -93,7 +92,7 @@ namespace trng {
         calc_probabilities();
       }
       param_type() = default;
-      explicit param_type(int n, int m, int d) : n_(n), m_(m), d_(d) { calc_probabilities(); }
+      explicit param_type(int n, int m, int d) : n_{n}, m_{m}, d_{d} { calc_probabilities(); }
       friend class hypergeometric_dist;
     };
 
@@ -102,8 +101,8 @@ namespace trng {
 
   public:
     // constructor
-    hypergeometric_dist(int n, int m, int d) : P(n, m, d) {}
-    explicit hypergeometric_dist(const param_type &P) : P(P) {}
+    explicit hypergeometric_dist(int n, int m, int d) : P{n, m, d} {}
+    explicit hypergeometric_dist(const param_type &P) : P{P} {}
     // reset internal state
     void reset() {}
     // random numbers
@@ -113,8 +112,8 @@ namespace trng {
              utility::discrete(utility::uniformoo<double>(r), P.P_.begin(), P.P_.end());
     }
     template<typename R>
-    int operator()(R &r, const param_type &p) {
-      hypergeometric_dist g(p);
+    int operator()(R &r, const param_type &P) {
+      hypergeometric_dist g(P);
       return g(r);
     }
     // property methods
@@ -150,13 +149,13 @@ namespace trng {
   // -------------------------------------------------------------------
 
   // EqualityComparable concept
-  inline bool operator==(const hypergeometric_dist::param_type &p1,
-                         const hypergeometric_dist::param_type &p2) {
-    return p1.n() == p2.n() and p1.m() == p2.m() and p1.d() == p2.d();
+  inline bool operator==(const hypergeometric_dist::param_type &P1,
+                         const hypergeometric_dist::param_type &P2) {
+    return P1.n() == P2.n() and P1.m() == P2.m() and P1.d() == P2.d();
   }
-  inline bool operator!=(const hypergeometric_dist::param_type &p1,
-                         const hypergeometric_dist::param_type &p2) {
-    return not(p1 == p2);
+  inline bool operator!=(const hypergeometric_dist::param_type &P1,
+                         const hypergeometric_dist::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // Streamable concept
@@ -208,13 +207,13 @@ namespace trng {
   template<typename char_t, typename traits_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    hypergeometric_dist &g) {
-    hypergeometric_dist::param_type p;
+    hypergeometric_dist::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[hypergeometric ") >> p >>
+    in >> utility::ignore_spaces() >> utility::delim("[hypergeometric ") >> P >>
         utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/int_math.hpp
+++ b/inst/include/trng/int_math.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,12 +34,12 @@
 
 #define TRNG_INT_MATH_HPP
 
+#include <trng/cuda.hpp>
+#include <trng/int_types.hpp>
 #include <cmath>
 #include <cassert>
 #include <algorithm>
 #include <stdexcept>
-#include <trng/cuda.hpp>
-#include <trng/int_types.hpp>
 #include <ciso646>
 
 namespace trng {
@@ -53,10 +53,10 @@ namespace trng {
         utility::throw_this(
             std::invalid_argument("invalid argument in trng::int_math::modulo_invers"));
 #endif
-      int32_t flast(0), f(1), m1(m);
+      int32_t flast{0}, f{1}, m1{m};
       while (a > 1) {
-        int32_t temp = m1 % a;
-        int32_t q = m1 / a;
+        int32_t temp{m1 % a};
+        int32_t q{m1 / a};
         m1 = a;
         a = temp;
         temp = f;
@@ -76,17 +76,17 @@ namespace trng {
     template<int n>
     TRNG_CUDA_ENABLE void gauss(int32_t a[n * n], int32_t b[n], int32_t m) {
       // initialize indices
-      int rank(0);
+      int rank{0};
       int32_t p[n];
-      for (int i(0); i < n; ++i)
+      for (int i{0}; i < n; ++i)
         p[i] = i;
       // make matrix triangular
-      for (int i(0); i < n; ++i) {
+      for (int i{0}; i < n; ++i) {
         // search for a pivot element
-        if (a[n * p[i] + i] == 0l) {
+        if (a[n * p[i] + i] == 0) {
           // swap rows
           int j = i + 1;
-          while (j < n and a[n * p[j] + i] == 0l)
+          while (j < n and a[n * p[j] + i] == 0)
             j++;
           if (j < n) {
             int32_t t = p[i];
@@ -95,64 +95,64 @@ namespace trng {
           }
         }
         // is rank small?
-        if (a[n * p[i] + i] == 0l)
+        if (a[n * p[i] + i] == 0)
           break;
         ++rank;
         int32_t t = modulo_invers(a[n * p[i] + i], m);
-        for (int j(i); j < n; ++j)
+        for (int j{i}; j < n; ++j)
           a[n * p[i] + j] = static_cast<int32_t>(
               (static_cast<int64_t>(a[n * p[i] + j]) * static_cast<int64_t>(t)) % m);
         b[p[i]] =
             static_cast<int32_t>((static_cast<int64_t>(b[p[i]]) * static_cast<int64_t>(t)) % m);
-        for (int j(i + 1); j < n; ++j) {
-          if (a[n * p[j] + i] != 0l) {
+        for (int j{i + 1}; j < n; ++j) {
+          if (a[n * p[j] + i] != 0) {
             t = modulo_invers(a[n * p[j] + i], m);
-            for (int k(i); k < n; ++k) {
+            for (int k{i}; k < n; ++k) {
               a[n * p[j] + k] = static_cast<int32_t>(
                   (static_cast<int64_t>(a[n * p[j] + k]) * static_cast<int64_t>(t)) % m);
               a[n * p[j] + k] -= a[n * p[i] + k];
-              if (a[n * p[j] + k] < 0l)
+              if (a[n * p[j] + k] < 0)
                 a[n * p[j] + k] += m;
             }
             b[p[j]] = static_cast<int32_t>(
                 (static_cast<int64_t>(b[p[j]]) * static_cast<int64_t>(t)) % m);
             b[p[j]] -= b[p[i]];
-            if (b[p[j]] < 0l)
+            if (b[p[j]] < 0)
               b[p[j]] += m;
           }
         }
       }
       // test if a solution exists
 #if !(defined __CUDA_ARCH__)
-      for (int i(rank); i < n; ++i)
-        if (b[p[i]] != 0l)
+      for (int i{rank}; i < n; ++i)
+        if (b[p[i]] != 0)
           utility::throw_this(
               std::runtime_error("equations system has no solution trng::int_math::gauss"));
 #endif
       // solve triangular system
-      for (int i(n - 2); i >= 0; --i)
-        for (int j(i + 1); j < n; ++j) {
+      for (int i{n - 2}; i >= 0; --i)
+        for (int j{i + 1}; j < n; ++j) {
           b[p[i]] -= static_cast<int32_t>(
               (static_cast<int64_t>(a[n * p[i] + j]) * static_cast<int64_t>(b[p[j]])) % m);
-          if (b[p[i]] < 0l)
+          if (b[p[i]] < 0)
             b[p[i]] += m;
         }
       // sort
-      for (int i(0); i < n; ++i)
+      for (int i{0}; i < n; ++i)
         p[i] = b[p[i]];
-      for (int i(0); i < n; ++i)
+      for (int i{0}; i < n; ++i)
         b[i] = p[i];
     }
 
     //------------------------------------------------------------------
 
     template<int n>
-    TRNG_CUDA_ENABLE void matrix_mult(const int32_t a[n * n], const int32_t b[n * n],
-                                      int32_t c[n * n], int32_t m) {
-      for (int i(0); i < n; ++i)
-        for (int j(0); j < n; ++j) {
-          int64_t t(0);
-          for (int k(0); k < n; ++k) {
+    TRNG_CUDA_ENABLE void matrix_mult(const int32_t (&a)[n * n], const int32_t (&b)[n * n],
+                                      int32_t (&c)[n * n], int32_t m) {
+      for (int i{0}; i < n; ++i)
+        for (int j{0}; j < n; ++j) {
+          int64_t t{0};
+          for (int k{0}; k < n; ++k) {
             t += (static_cast<int64_t>(a[j * n + k]) * static_cast<int64_t>(b[k * n + i])) % m;
             if (t >= m)
               t -= m;
@@ -164,11 +164,11 @@ namespace trng {
     //------------------------------------------------------------------
 
     template<int n>
-    TRNG_CUDA_ENABLE void matrix_vec_mult(const int32_t a[n * n], const int32_t b[n],
-                                          int32_t c[n], int32_t m) {
-      for (int j(0); j < n; ++j) {
-        int64_t t(0);
-        for (int k(0); k < n; ++k) {
+    TRNG_CUDA_ENABLE void matrix_vec_mult(const int32_t (&a)[n * n], const int32_t (&b)[n],
+                                          int32_t (&c)[n], int32_t m) {
+      for (int j{0}; j < n; ++j) {
+        int64_t t{0};
+        for (int k{0}; k < n; ++k) {
           t += (static_cast<int64_t>(a[j * n + k]) * static_cast<int64_t>(b[k])) % m;
           if (t >= m)
             t -= m;
@@ -179,28 +179,32 @@ namespace trng {
 
     // ---------------------------------------------------------------
 
-    template<int32_t m>
-    struct log2_floor {
-      enum { value = 1 + log2_floor<m / 2>::value };
-    };
+    template<typename T>
+    constexpr T pow2(const T x) {
+      return T(1) << x;
+    }
 
-    template<>
-    struct log2_floor<0> {
-      enum { value = 0 };
-    };
+    template<typename T>
+    constexpr T log2_floor(const T x) {
+      return x <= T(1) ? T(0) : T(1) + log2_floor(x / T(2));
+    }
 
-    template<>
-    struct log2_floor<1> {
-      enum { value = 0 };
-    };
+    template<typename T>
+    constexpr T log2_ceil(const T x) {
+      return pow2(log2_floor(x)) < x ? log2_floor(x) + 1 : log2_floor(x);
+    }
 
-    template<int32_t m>
-    struct log2_ceil {
-      enum {
-        value =
-            (1ul << log2_floor<m>::value) < m ? log2_floor<m>::value + 1 : log2_floor<m>::value
-      };
-    };
+    // round upwards to next power of 2
+    template<typename T>
+    constexpr T ceil2(const T x) {
+      return x <= T(1) ? x : T(2) * ceil2((x + T(1)) / T(2));
+    }
+
+    // sets all bits below the argument's most significant bit to one
+    template<typename T>
+    constexpr T mask(const T x) {
+      return ceil2(x + T(1)) - T(1);
+    }
 
     // ---------------------------------------------------------------
 
@@ -209,47 +213,48 @@ namespace trng {
 
     template<int32_t m>
     class modulo_helper<m, 0> {
-      static const int32_t e = log2_ceil<m>::value;
-      static const int32_t k = (1ul << e) - m;
-      static const uint32_t mask = (1ul << e) - 1ul;
+      static constexpr int32_t e = log2_ceil(m);
+      static constexpr int32_t k = (1ul << e) - m;
+      static constexpr uint32_t mask = (1ul << e) - 1ul;
 
     public:
       TRNG_CUDA_ENABLE
-      inline static int32_t modulo(uint64_t x) {
+      static int32_t modulo(uint64_t x) {
         if (mask == m) {
-          uint32_t y = static_cast<int32_t>((x & mask) + (x >> e));
+          uint32_t y{static_cast<uint32_t>((x & mask) + (x >> e))};
           if (y >= m)
             y -= m;
           return y;
-        } else if (static_cast<int64_t>(k) * (static_cast<int64_t>(k) + 2) <= m) {
+        }
+        if (static_cast<int64_t>(k) * (static_cast<int64_t>(k) + 2) <= m) {
           x = (x & mask) + (x >> e) * k;
           x = (x & mask) + (x >> e) * k;
           if (x >= m)
             x -= m;
           return static_cast<int32_t>(x);
-        } else {
-          return static_cast<int32_t>(x % m);
         }
+        return static_cast<int32_t>(x % m);
       }
     };
 
     template<int32_t m>
     class modulo_helper<m, 1> {
-      static const int32_t e = log2_ceil<m>::value;
-      static const int32_t k = (static_cast<uint32_t>(1) << e) - m;
-      static const uint32_t mask = (static_cast<uint32_t>(1) << e) - 1u;
+      static constexpr int32_t e = log2_ceil(m);
+      static constexpr int32_t k = (static_cast<uint32_t>(1) << e) - m;
+      static constexpr uint32_t mask = (static_cast<uint32_t>(1) << e) - 1u;
 
     public:
       TRNG_CUDA_ENABLE
-      inline static int32_t modulo(uint64_t x) {
+      static int32_t modulo(uint64_t x) {
         if (mask == m) {
-          uint64_t y = (x & mask) + (x >> e);
+          uint64_t y{(x & mask) + (x >> e)};
           if (y >= static_cast<uint64_t>(2u) * m)
             y -= static_cast<uint64_t>(2u) * m;
           if (y >= m)
             y -= m;
           return static_cast<int32_t>(y);
-        } else if (static_cast<int64_t>(k) * (static_cast<int64_t>(k) + 2) <= m) {
+        }
+        if (static_cast<int64_t>(k) * (static_cast<int64_t>(k) + 2) <= m) {
           x = (x & mask) + (x >> e) * k;
           x = (x & mask) + (x >> e) * k;
           if (x >= static_cast<uint64_t>(2u) * m)
@@ -257,23 +262,22 @@ namespace trng {
           if (x >= m)
             x -= m;
           return static_cast<int32_t>(x);
-        } else {
-          return static_cast<int32_t>(x % m);
         }
+        return static_cast<int32_t>(x % m);
       }
     };
 
     template<int32_t m>
     class modulo_helper<m, 2> {
-      static const int32_t e = log2_ceil<m>::value;
-      static const int32_t k = (static_cast<uint32_t>(1) << e) - m;
-      static const uint32_t mask = (static_cast<uint32_t>(1) << e) - 1u;
+      static constexpr int32_t e = log2_ceil(m);
+      static constexpr int32_t k = (static_cast<uint32_t>(1) << e) - m;
+      static constexpr uint32_t mask = (static_cast<uint32_t>(1) << e) - 1u;
 
     public:
       TRNG_CUDA_ENABLE
-      inline static int32_t modulo(uint64_t x) {
+      static int32_t modulo(uint64_t x) {
         if (mask == m) {
-          uint64_t y = (x & mask) + (x >> e);
+          uint64_t y{(x & mask) + (x >> e)};
           if (y >= static_cast<uint64_t>(4u) * m)
             y -= static_cast<uint64_t>(4u) * m;
           if (y >= static_cast<uint64_t>(2u) * m)
@@ -281,7 +285,8 @@ namespace trng {
           if (y >= m)
             y -= m;
           return static_cast<int32_t>(y);
-        } else if (static_cast<int64_t>(k) * (static_cast<int64_t>(k) + 2) <= m) {
+        }
+        if (static_cast<int64_t>(k) * (static_cast<int64_t>(k) + 2) <= m) {
           x = (x & mask) + (x >> e) * k;
           x = (x & mask) + (x >> e) * k;
           if (x >= static_cast<uint64_t>(4u) * m)
@@ -291,15 +296,16 @@ namespace trng {
           if (x >= m)
             x -= m;
           return static_cast<int32_t>(x);
-        } else {
-          return static_cast<int32_t>(x % m);
         }
+        return static_cast<int32_t>(x % m);
       }
     };
 
     template<int32_t m, int32_t r>
     TRNG_CUDA_ENABLE inline int32_t modulo(uint64_t x) {
-      return modulo_helper<m, log2_floor<r>::value>::modulo(x);
+      static_assert(m > 0, "must be positive");
+      static_assert(r > 0, "must be positive");
+      return modulo_helper<m, log2_floor(r)>::modulo(x);
     }
 
     //------------------------------------------------------------------
@@ -308,8 +314,8 @@ namespace trng {
     class power {
       uint32_t b_power0[0x10000], b_power1[0x08000];
 
-      inline int32_t pow(int32_t n) {
-        int64_t p(1), t(b);
+      int32_t pow(int32_t n) {
+        int64_t p{1}, t{b};
         while (n > 0) {
           if ((n & 0x1) == 0x1)
             p = modulo<m, 1>(p * t);
@@ -325,12 +331,12 @@ namespace trng {
       power(const power &) = delete;
 
       power() {
-        for (int32_t i(0); i < 0x10000; ++i)
+        for (int32_t i{0}; i < 0x10000; ++i)
           b_power0[i] = pow(i);
-        for (int32_t i(0); i < 0x08000; ++i)
+        for (int32_t i{0}; i < 0x08000; ++i)
           b_power1[i] = pow(i * 0x10000);
       }
-      inline int32_t operator()(int32_t n) const {
+      int32_t operator()(int32_t n) const {
         return modulo<m, 1>(static_cast<uint64_t>(b_power1[n >> 16]) *
                             static_cast<uint64_t>(b_power0[n & 0xffff]));
       }

--- a/inst/include/trng/int_types.hpp
+++ b/inst/include/trng/int_types.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/inst/include/trng/lagfib2xor.hpp
+++ b/inst/include/trng/lagfib2xor.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -35,65 +35,56 @@
 #define TRNG_LAGFIB2XOR_HPP
 
 #include <trng/limits.hpp>
+#include <trng/utility.hpp>
+#include <trng/minstd.hpp>
+#include <trng/int_types.hpp>
+#include <trng/linear_algebra.hpp>
 #include <climits>
 #include <stdexcept>
 #include <ostream>
 #include <istream>
 #include <sstream>
-#include <trng/utility.hpp>
-#include <trng/minstd.hpp>
-#include <trng/int_types.hpp>
 #include <ciso646>
 
 namespace trng {
 
   template<typename integer_type, unsigned int A, unsigned int B>
-  class lagfib2xor;
-
-  template<typename integer_type, unsigned int A, unsigned int B>
   class lagfib2xor {
   public:
     // Uniform random number generator concept
-    typedef integer_type result_type;
+    using result_type = integer_type;
     result_type operator()() {
       step();
       return S.r[S.index];
     }
 
   private:
-    static const result_type min_ = 0;
-    static const result_type max_ = ~result_type(0);
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = ~result_type(0);
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class status_type;
-
     class status_type {
-      result_type r[utility::ceil2<B>::result];
-      unsigned int index;
-      static unsigned int size() { return utility::ceil2<B>::result; }
+      result_type r[int_math::ceil2(B)]{};
+      unsigned int index{0};
+      static constexpr unsigned int size() { return int_math::ceil2(B); }
 
     public:
-      status_type() {
-        for (unsigned int i = 0; i < size(); ++i)
-          r[i] = 0;
-        index = 0;
-      };
-
       friend class lagfib2xor;
 
       // Equality comparable concept
       friend bool operator==(const status_type &a, const status_type &b) {
         if (a.index != b.index)
           return false;
-        for (unsigned int i = 0; i < a.size(); ++i)
+        for (unsigned int i{0}; i < a.size(); ++i)
           if (a.r[i] != b.r[i])
             return false;
         return true;
       }
+
       friend bool operator!=(const status_type &a, const status_type &b) { return not(a == b); }
 
       // Streamable concept
@@ -103,7 +94,7 @@ namespace trng {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         out << '(' << S.index;
-        for (unsigned int i = 0; i < S.size(); ++i)
+        for (unsigned int i{0}; i < S.size(); ++i)
           out << ' ' << S.r[i];
         out << ')';
         out.flags(flags);
@@ -117,7 +108,7 @@ namespace trng {
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> S_new.index;
-        for (unsigned int i = 0; i < S.size(); ++i)
+        for (unsigned int i{0}; i < S.size(); ++i)
           in >> utility::delim(' ') >> S_new.r[i];
         in >> utility::delim(')');
         if (in)
@@ -128,12 +119,12 @@ namespace trng {
     };
 
     // Random number engine concept
-    lagfib2xor() : S() { seed(); }
+    lagfib2xor() { seed(); }
 
-    explicit lagfib2xor(unsigned long s) : S() { seed(s); }
+    explicit lagfib2xor(unsigned long s) { seed(s); }
 
     template<typename gen>
-    explicit lagfib2xor(gen &g) : S() {
+    explicit lagfib2xor(gen &g) {
       seed(g);
     }
 
@@ -146,9 +137,9 @@ namespace trng {
 
     template<typename gen>
     void seed(gen &g) {
-      for (unsigned int i = 0; i < B; ++i) {
-        result_type r = 0;
-        for (int j = 0; j < std::numeric_limits<result_type>::digits; ++j) {
+      for (unsigned int i{0}; i < B; ++i) {
+        result_type r{0};
+        for (int j{0}; j < std::numeric_limits<result_type>::digits; ++j) {
           r <<= 1;
           if (g() - gen::min() > gen::max() / 2)
             ++r;
@@ -159,7 +150,37 @@ namespace trng {
     }
 
     void discard(unsigned long long n) {
-      for (unsigned long long i(0); i < n; ++i)
+      const unsigned int matrix_size = B;
+      using matrix_type = matrix<GF2, matrix_size>;
+      using vector_type = vector<result_type, matrix_size>;
+      using size_type = typename matrix_type::size_type;
+      const unsigned long long n_pivot{int_math::log2_ceil(n) * B * B * B};
+      constexpr auto mask = int_math::mask(B);
+      if (n > n_pivot) {
+        const unsigned long long n_partial{n - matrix_size};
+        matrix_type M;
+        for (size_type i{0}; i < matrix_size - 1; ++i)
+          M(i, i + 1) = GF2(true);
+        M(matrix_size - 1, matrix_size - B) = GF2(true);
+        M(matrix_size - 1, matrix_size - A) = GF2(true);
+        M = power(M, n_partial);
+        vector_type V;
+        for (size_type i{0}; i < matrix_size; ++i)
+          V(matrix_size - 1 - i) = S.r[(S.index - i) & mask];
+        vector_type W;
+        for (size_type i{0}; i < matrix_size; ++i) {
+          result_type sum{};
+          for (size_type k{0}; k < matrix_size; ++k)
+            sum ^= M(i, k) * V(k);
+          W(i) = sum;
+        }
+        S.index += n_partial;
+        S.index &= mask;
+        for (size_type i{0}; i < matrix_size; ++i)
+          S.r[(S.index - i) & mask] = W(matrix_size - 1 - i);
+        n -= n_partial;
+      }
+      for (unsigned long long i{0}; i < n; ++i)
         step();
     }
 
@@ -216,10 +237,10 @@ namespace trng {
     status_type S;
 
     void step() {
-      S.index++;
-      S.index &= utility::mask<B>::result;
-      S.r[S.index] = S.r[(S.index - A) & utility::mask<B>::result] ^
-                     S.r[(S.index - B) & utility::mask<B>::result];
+      ++S.index;
+      S.index &= int_math::mask(B);
+      S.r[S.index] =
+          S.r[(S.index - A) & int_math::mask(B)] ^ S.r[(S.index - B) & int_math::mask(B)];
     }
   };
 

--- a/inst/include/trng/lagfib4plus.hpp
+++ b/inst/include/trng/lagfib4plus.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -35,67 +35,56 @@
 #define TRNG_LAGFIB4PLUS_HPP
 
 #include <trng/limits.hpp>
+#include <trng/utility.hpp>
+#include <trng/minstd.hpp>
+#include <trng/int_types.hpp>
 #include <climits>
 #include <stdexcept>
 #include <ostream>
 #include <istream>
 #include <sstream>
-#include <trng/utility.hpp>
-#include <trng/minstd.hpp>
-#include <trng/int_types.hpp>
 #include <ciso646>
 
 namespace trng {
 
   template<typename integer_type, unsigned int A, unsigned int B, unsigned int C,
            unsigned int D>
-  class lagfib4plus;
-
-  template<typename integer_type, unsigned int A, unsigned int B, unsigned int C,
-           unsigned int D>
   class lagfib4plus {
   public:
     // Uniform random number generator concept
-    typedef integer_type result_type;
+    using result_type = integer_type;
     result_type operator()() {
       step();
       return S.r[S.index];
     }
 
   private:
-    static const result_type min_ = 0;
-    static const result_type max_ = ~result_type(0);
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = ~result_type(0);
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class status_type;
-
     class status_type {
-      result_type r[utility::ceil2<D>::result];
-      unsigned int index;
-      static unsigned int size() { return utility::ceil2<D>::result; }
+      result_type r[int_math::ceil2(D)]{};
+      unsigned int index{0};
+      static constexpr unsigned int size() { return int_math::ceil2(D); }
 
     public:
-      status_type() {
-        for (unsigned int i = 0; i < size(); ++i)
-          r[i] = 0;
-        index = 0;
-      };
-
       friend class lagfib4plus;
 
       // Equality comparable concept
       friend bool operator==(const status_type &a, const status_type &b) {
         if (a.index != b.index)
           return false;
-        for (unsigned int i = 0; i < a.size(); ++i)
+        for (unsigned int i{0}; i < a.size(); ++i)
           if (a.r[i] != b.r[i])
             return false;
         return true;
       }
+
       friend bool operator!=(const status_type &a, const status_type &b) { return not(a == b); }
 
       // Streamable concept
@@ -105,7 +94,7 @@ namespace trng {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         out << '(' << S.index;
-        for (unsigned int i = 0; i < S.size(); ++i)
+        for (unsigned int i{0}; i < S.size(); ++i)
           out << ' ' << S.r[i];
         out << ')';
         out.flags(flags);
@@ -119,7 +108,7 @@ namespace trng {
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> S_new.index;
-        for (unsigned int i = 0; i < S.size(); ++i)
+        for (unsigned int i{0}; i < S.size(); ++i)
           in >> utility::delim(' ') >> S_new.r[i];
         in >> utility::delim(')');
         if (in)
@@ -130,12 +119,12 @@ namespace trng {
     };
 
     // Random number engine concept
-    lagfib4plus() : S() { seed(); }
+    lagfib4plus() { seed(); }
 
-    explicit lagfib4plus(unsigned long s) : S() { seed(s); }
+    explicit lagfib4plus(unsigned long s) { seed(s); }
 
     template<typename gen>
-    explicit lagfib4plus(gen &g) : S() {
+    explicit lagfib4plus(gen &g) {
       seed(g);
     }
 
@@ -148,9 +137,9 @@ namespace trng {
 
     template<typename gen>
     void seed(gen &g) {
-      for (unsigned int i = 0; i < D; ++i) {
-        result_type r = 0;
-        for (int j = 0; j < std::numeric_limits<result_type>::digits; ++j) {
+      for (unsigned int i{0}; i < D; ++i) {
+        result_type r{0};
+        for (int j{0}; j < std::numeric_limits<result_type>::digits; ++j) {
           r <<= 1;
           if (g() - gen::min() > gen::max() / 2)
             ++r;
@@ -161,7 +150,33 @@ namespace trng {
     }
 
     void discard(unsigned long long n) {
-      for (unsigned long long i(0); i < n; ++i)
+      const unsigned int matrix_size = D;
+      using matrix_type = matrix<result_type, matrix_size>;
+      using vector_type = vector<result_type, matrix_size>;
+      using size_type = typename matrix_type::size_type;
+      const unsigned long long n_pivot{int_math::log2_ceil(n) * D * D * D};
+      constexpr auto mask = int_math::mask(D);
+      if (n > n_pivot) {
+        const unsigned long long n_partial{n - matrix_size};
+        matrix_type M;
+        for (size_type i{0}; i < matrix_size - 1; ++i)
+          M(i, i + 1) = 1;
+        M(matrix_size - 1, matrix_size - D) = 1;
+        M(matrix_size - 1, matrix_size - C) = 1;
+        M(matrix_size - 1, matrix_size - B) = 1;
+        M(matrix_size - 1, matrix_size - A) = 1;
+        M = power(M, n_partial);
+        vector_type V;
+        for (size_type i{0}; i < matrix_size; ++i)
+          V(matrix_size - 1 - i) = S.r[(S.index - i) & mask];
+        V = M * V;
+        S.index += n_partial;
+        S.index &= mask;
+        for (size_type i{0}; i < matrix_size; ++i)
+          S.r[(S.index - i) & mask] = V(matrix_size - 1 - i);
+        n -= n_partial;
+      }
+      for (unsigned long long i{0}; i < n; ++i)
         step();
     }
 
@@ -222,12 +237,11 @@ namespace trng {
     status_type S;
 
     void step() {
-      S.index++;
-      S.index &= utility::mask<D>::result;
-      S.r[S.index] = S.r[(S.index - A) & utility::mask<D>::result] +
-                     S.r[(S.index - B) & utility::mask<D>::result] +
-                     S.r[(S.index - C) & utility::mask<D>::result] +
-                     S.r[(S.index - D) & utility::mask<D>::result];
+      ++S.index;
+      S.index &= int_math::mask(D);
+      S.r[S.index] =
+          S.r[(S.index - A) & int_math::mask(D)] + S.r[(S.index - B) & int_math::mask(D)] +
+          S.r[(S.index - C) & int_math::mask(D)] + S.r[(S.index - D) & int_math::mask(D)];
     }
   };
 

--- a/inst/include/trng/lcg64.hpp
+++ b/inst/include/trng/lcg64.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -36,29 +36,27 @@
 
 #include <trng/cuda.hpp>
 #include <trng/limits.hpp>
+#include <trng/utility.hpp>
+#include <trng/int_types.hpp>
+#include <trng/generate_canonical.hpp>
 #include <climits>
 #include <stdexcept>
 #include <ostream>
 #include <istream>
-#include <trng/utility.hpp>
-#include <trng/int_types.hpp>
-#include <trng/generate_canonical.hpp>
 #include <ciso646>
 
 namespace trng {
 
-  class lcg64;
-
   class lcg64 {
   public:
     // Uniform random number generator concept
-    typedef uint64_t result_type;
+    using result_type = uint64_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type min_ = 0;
-    static const result_type max_ = 18446744073709551615u;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = ~result_type(0);
 
   public:
     static constexpr result_type min() { return min_; }
@@ -80,15 +78,12 @@ namespace trng {
 
   public:
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
     class parameter_type {
-      result_type a, b;
+      result_type a{0}, b{0};
 
     public:
-      parameter_type() : a(0), b(0){};
-      parameter_type(result_type a, result_type b) : a(a), b(b){};
+      parameter_type() = default;
+      explicit parameter_type(result_type a, result_type b) : a{a}, b{b} {};
 
       friend class lcg64;
 
@@ -123,11 +118,11 @@ namespace trng {
     };
 
     class status_type {
-      result_type r;
+      result_type r{0};
 
     public:
-      status_type() : r(0){};
-      explicit status_type(result_type r) : r(r){};
+      status_type() = default;
+      explicit status_type(result_type r) : r{r} {};
 
       friend class lcg64;
 
@@ -171,7 +166,7 @@ namespace trng {
     explicit lcg64(unsigned long long, parameter_type = Default);
 
     template<typename gen>
-    explicit lcg64(gen &g, parameter_type P = Default) : P(P), S() {
+    explicit lcg64(gen &g, parameter_type P = Default) : P{P} {
       seed(g);
     }
 
@@ -179,9 +174,9 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      result_type r = 0;
-      for (int i = 0; i < 2; ++i) {
-        r <<= 32;
+      result_type r{0};
+      for (int i{0}; i < 2; ++i) {
+        r <<= 32u;
         r += g();
       }
       S.r = r;
@@ -266,9 +261,9 @@ namespace trng {
   // compute floor(log_2(x))
   TRNG_CUDA_ENABLE
   inline unsigned int lcg64::log2_floor(lcg64::result_type x) {
-    unsigned int y(0);
+    unsigned int y{0};
     while (x > 0) {
-      x >>= 1;
+      x >>= 1u;
       ++y;
     }
     --y;
@@ -278,12 +273,12 @@ namespace trng {
   // compute pow(x, n)
   TRNG_CUDA_ENABLE
   inline lcg64::result_type lcg64::pow(lcg64::result_type x, lcg64::result_type n) {
-    lcg64::result_type result = 1;
+    lcg64::result_type result{1};
     while (n > 0) {
-      if ((n & 1) > 0)
-        result = result * x;
-      x = x * x;
-      n >>= 1;
+      if ((n & 1u) > 0)
+        result *= x;
+      x *= x;
+      n >>= 1u;
     }
     return result;
   }
@@ -291,8 +286,8 @@ namespace trng {
   // compute prod(1+a^(2^i), i=0..l-1)
   TRNG_CUDA_ENABLE
   inline lcg64::result_type lcg64::g(unsigned int l, lcg64::result_type a) {
-    lcg64::result_type p = a, res = 1;
-    for (unsigned i = 0; i < l; ++i) {
+    lcg64::result_type p{a}, res{1};
+    for (unsigned i{0}; i < l; ++i) {
       res *= 1 + p;
       p *= p;
     }
@@ -304,9 +299,9 @@ namespace trng {
   inline lcg64::result_type lcg64::f(lcg64::result_type s, lcg64::result_type a) {
     if (s == 0)
       return 0;
-    unsigned int e = log2_floor(s);
-    lcg64::result_type y = 0, p = a;
-    for (unsigned int l = 0; l <= e; ++l) {
+    const unsigned int e{log2_floor(s)};
+    lcg64::result_type y{0}, p{a};
+    for (unsigned int l{0}; l <= e; ++l) {
       if (((1ull << l) & s) > 0) {
         y = g(l, a) + p * y;
       }
@@ -339,25 +334,25 @@ namespace trng {
   TRNG_CUDA_ENABLE
   inline void lcg64::jump(unsigned long long s) {
     if (s < 16) {
-      for (unsigned int i(0); i < s; ++i)
+      for (unsigned int i{0}; i < s; ++i)
         step();
     } else {
-      unsigned int i(0);
+      unsigned int i{0};
       while (s > 0) {
         if (s % 2 == 1)
           jump2(i);
         ++i;
-        s >>= 1;
+        s >>= 1u;
       }
     }
   }
 
   TRNG_CUDA_ENABLE
-  inline void lcg64::discard(unsigned long long n) { return jump(n); }
+  inline void lcg64::discard(unsigned long long n) { jump(n); }
 
   TRNG_CUDA_ENABLE
   inline void lcg64::backward() {
-    for (unsigned int i(0); i < 64; ++i)
+    for (unsigned int i{0}; i < 64; ++i)
       jump2(i);
   }
 

--- a/inst/include/trng/lcg64_shift.hpp
+++ b/inst/include/trng/lcg64_shift.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -36,29 +36,27 @@
 
 #include <trng/cuda.hpp>
 #include <trng/limits.hpp>
+#include <trng/utility.hpp>
+#include <trng/int_types.hpp>
+#include <trng/generate_canonical.hpp>
 #include <climits>
 #include <stdexcept>
 #include <ostream>
 #include <istream>
-#include <trng/utility.hpp>
-#include <trng/int_types.hpp>
-#include <trng/generate_canonical.hpp>
 #include <ciso646>
 
 namespace trng {
 
-  class lcg64_shift;
-
   class lcg64_shift {
   public:
     // Uniform random number generator concept
-    typedef uint64_t result_type;
+    using result_type = uint64_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type min_ = 0;
-    static const result_type max_ = 18446744073709551615u;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = ~result_type(0);
 
   public:
     static constexpr result_type min() { return min_; }
@@ -80,15 +78,12 @@ namespace trng {
 
   public:
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
     class parameter_type {
-      result_type a, b;
+      result_type a{0}, b{0};
 
     public:
-      parameter_type() : a(0), b(0){};
-      parameter_type(result_type a, result_type b) : a(a), b(b){};
+      parameter_type() = default;
+      explicit parameter_type(result_type a, result_type b) : a{a}, b{b} {};
 
       friend class lcg64_shift;
 
@@ -123,11 +118,11 @@ namespace trng {
     };
 
     class status_type {
-      result_type r;
+      result_type r{0};
 
     public:
-      status_type() : r(0){};
-      explicit status_type(result_type r) : r(r){};
+      status_type() = default;
+      explicit status_type(result_type r) : r{r} {};
 
       friend class lcg64_shift;
 
@@ -171,7 +166,7 @@ namespace trng {
     explicit lcg64_shift(unsigned long long, parameter_type = Default);
 
     template<typename gen>
-    explicit lcg64_shift(gen &g, parameter_type P = Default) : P(P), S() {
+    explicit lcg64_shift(gen &g, parameter_type P = Default) : P{P} {
       seed(g);
     }
 
@@ -180,8 +175,8 @@ namespace trng {
     template<typename gen>
     void seed(gen &g) {
       result_type r = 0;
-      for (int i = 0; i < 2; ++i) {
-        r <<= 32;
+      for (int i{0}; i < 2; ++i) {
+        r <<= 32u;
         r += g();
       }
       S.r = r;
@@ -256,9 +251,9 @@ namespace trng {
   inline lcg64_shift::result_type lcg64_shift::operator()() {
     step();
     unsigned long long t = S.r;
-    t ^= (t >> 17);
-    t ^= (t << 31);
-    t ^= (t >> 8);
+    t ^= (t >> 17u);
+    t ^= (t << 31u);
+    t ^= (t >> 8u);
     return t;
   }
 
@@ -270,9 +265,9 @@ namespace trng {
   // compute floor(log_2(x))
   TRNG_CUDA_ENABLE
   inline unsigned int lcg64_shift::log2_floor(lcg64_shift::result_type x) {
-    unsigned int y(0);
+    unsigned int y{0};
     while (x > 0) {
-      x >>= 1;
+      x >>= 1u;
       ++y;
     }
     --y;
@@ -283,12 +278,12 @@ namespace trng {
   TRNG_CUDA_ENABLE
   inline lcg64_shift::result_type lcg64_shift::pow(lcg64_shift::result_type x,
                                                    lcg64_shift::result_type n) {
-    lcg64_shift::result_type result = 1;
+    lcg64_shift::result_type result{1};
     while (n > 0) {
-      if ((n & 1) > 0)
-        result = result * x;
-      x = x * x;
-      n >>= 1;
+      if ((n & 1u) > 0)
+        result *= x;
+      x *= x;
+      n >>= 1u;
     }
     return result;
   }
@@ -297,7 +292,7 @@ namespace trng {
   TRNG_CUDA_ENABLE
   inline lcg64_shift::result_type lcg64_shift::g(unsigned int l, lcg64_shift::result_type a) {
     lcg64_shift::result_type p = a, res = 1;
-    for (unsigned i = 0; i < l; ++i) {
+    for (unsigned i{0}; i < l; ++i) {
       res *= 1 + p;
       p *= p;
     }
@@ -310,9 +305,9 @@ namespace trng {
                                                  lcg64_shift::result_type a) {
     if (s == 0)
       return 0;
-    unsigned int e = log2_floor(s);
-    lcg64_shift::result_type y = 0, p = a;
-    for (unsigned int l = 0; l <= e; ++l) {
+    const unsigned int e{log2_floor(s)};
+    lcg64_shift::result_type y{0}, p{a};
+    for (unsigned int l{0}; l <= e; ++l) {
       if (((1ull << l) & s) > 0) {
         y = g(l, a) + p * y;
       }
@@ -346,25 +341,25 @@ namespace trng {
   TRNG_CUDA_ENABLE
   inline void lcg64_shift::jump(unsigned long long s) {
     if (s < 16) {
-      for (unsigned int i(0); i < s; ++i)
+      for (unsigned int i{0}; i < s; ++i)
         step();
     } else {
-      unsigned int i(0);
+      unsigned int i{0};
       while (s > 0) {
         if (s % 2 == 1)
           jump2(i);
         ++i;
-        s >>= 1;
+        s >>= 1u;
       }
     }
   }
 
   TRNG_CUDA_ENABLE
-  inline void lcg64_shift::discard(unsigned long long n) { return jump(n); }
+  inline void lcg64_shift::discard(unsigned long long n) { jump(n); }
 
   TRNG_CUDA_ENABLE
   inline void lcg64_shift::backward() {
-    for (unsigned int i(0); i < 64; ++i)
+    for (unsigned int i{0}; i < 64; ++i)
       jump2(i);
   }
 

--- a/inst/include/trng/limits.hpp
+++ b/inst/include/trng/limits.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -50,36 +50,44 @@ namespace trng {
     template<typename T>
     class numeric_limits {
     public:
-      static const bool is_specialized = ::std::numeric_limits<T>::is_specialized;
-      static T min() noexcept { return ::std::numeric_limits<T>::min(); }
-      static T max() noexcept { return ::std::numeric_limits<T>::max(); }
-      static const int digits = ::std::numeric_limits<T>::digits;
-      static const int digits10 = ::std::numeric_limits<T>::digits10;
-      static const bool is_signed = ::std::numeric_limits<T>::is_signed;
-      static const bool is_integer = ::std::numeric_limits<T>::is_integer;
-      static const bool is_exact = ::std::numeric_limits<T>::is_exact;
-      static const int radix = ::std::numeric_limits<T>::radix;
-      static T epsilon() noexcept { return ::std::numeric_limits<T>::epsilon(); }
-      static T round_error() noexcept { return ::std::numeric_limits<T>::round_error(); }
-      static const int min_exponent = ::std::numeric_limits<T>::min_exponent;
-      static const int min_exponent10 = ::std::numeric_limits<T>::min_exponent10;
-      static const int max_exponent = ::std::numeric_limits<T>::max_exponent;
-      static const int max_exponent10 = ::std::numeric_limits<T>::max_exponent10;
-      static const bool has_infinity = ::std::numeric_limits<T>::has_infinity;
-      static const bool has_quiet_NaN = ::std::numeric_limits<T>::has_quiet_NaN;
-      static const bool has_signaling_NaN = ::std::numeric_limits<T>::has_signaling_NaN;
-      static const ::std::float_denorm_style has_denorm = ::std::numeric_limits<T>::has_denorm;
-      static const bool has_denorm_loss = ::std::numeric_limits<T>::has_denorm_loss;
-      static T infinity() noexcept { return ::std::numeric_limits<T>::infinity(); }
-      static T quiet_NaN() noexcept { return ::std::numeric_limits<T>::quiet_NaN(); }
-      static T signaling_NaN() noexcept { return ::std::numeric_limits<T>::signaling_NaN(); }
-      static T denorm_min() noexcept { return ::std::numeric_limits<T>::denorm_min(); }
-      static const bool is_iec559 = ::std::numeric_limits<T>::is_iec559;
-      static const bool is_bounded = ::std::numeric_limits<T>::is_bounded;
-      static const bool is_modulo = ::std::numeric_limits<T>::is_modulo;
-      static const bool traps = ::std::numeric_limits<T>::traps;
-      static const bool tinyness_before = ::std::numeric_limits<T>::tinyness_before;
-      static const ::std::float_round_style round_style = ::std::numeric_limits<T>::round_style;
+      static constexpr bool is_specialized = ::std::numeric_limits<T>::is_specialized;
+      static constexpr T min() noexcept { return ::std::numeric_limits<T>::min(); }
+      static constexpr T max() noexcept { return ::std::numeric_limits<T>::max(); }
+      static constexpr int digits = ::std::numeric_limits<T>::digits;
+      static constexpr int digits10 = ::std::numeric_limits<T>::digits10;
+      static constexpr bool is_signed = ::std::numeric_limits<T>::is_signed;
+      static constexpr bool is_integer = ::std::numeric_limits<T>::is_integer;
+      static constexpr bool is_exact = ::std::numeric_limits<T>::is_exact;
+      static constexpr int radix = ::std::numeric_limits<T>::radix;
+      static constexpr T epsilon() noexcept { return ::std::numeric_limits<T>::epsilon(); }
+      static constexpr T round_error() noexcept {
+        return ::std::numeric_limits<T>::round_error();
+      }
+      static constexpr int min_exponent = ::std::numeric_limits<T>::min_exponent;
+      static constexpr int min_exponent10 = ::std::numeric_limits<T>::min_exponent10;
+      static constexpr int max_exponent = ::std::numeric_limits<T>::max_exponent;
+      static constexpr int max_exponent10 = ::std::numeric_limits<T>::max_exponent10;
+      static constexpr bool has_infinity = ::std::numeric_limits<T>::has_infinity;
+      static constexpr bool has_quiet_NaN = ::std::numeric_limits<T>::has_quiet_NaN;
+      static constexpr bool has_signaling_NaN = ::std::numeric_limits<T>::has_signaling_NaN;
+      static constexpr ::std::float_denorm_style has_denorm =
+          ::std::numeric_limits<T>::has_denorm;
+      static constexpr bool has_denorm_loss = ::std::numeric_limits<T>::has_denorm_loss;
+      static constexpr T infinity() noexcept { return ::std::numeric_limits<T>::infinity(); }
+      static constexpr T quiet_NaN() noexcept { return ::std::numeric_limits<T>::quiet_NaN(); }
+      static constexpr T signaling_NaN() noexcept {
+        return ::std::numeric_limits<T>::signaling_NaN();
+      }
+      static constexpr T denorm_min() noexcept {
+        return ::std::numeric_limits<T>::denorm_min();
+      }
+      static constexpr bool is_iec559 = ::std::numeric_limits<T>::is_iec559;
+      static constexpr bool is_bounded = ::std::numeric_limits<T>::is_bounded;
+      static constexpr bool is_modulo = ::std::numeric_limits<T>::is_modulo;
+      static constexpr bool traps = ::std::numeric_limits<T>::traps;
+      static constexpr bool tinyness_before = ::std::numeric_limits<T>::tinyness_before;
+      static constexpr ::std::float_round_style round_style =
+          ::std::numeric_limits<T>::round_style;
     };
 
     // --- float ---
@@ -87,9 +95,9 @@ namespace trng {
     template<>
     class numeric_limits<float> {
     public:
-      static const bool is_specialized = ::std::numeric_limits<float>::is_specialized;
+      static constexpr bool is_specialized = ::std::numeric_limits<float>::is_specialized;
       TRNG_CUDA_ENABLE
-      static float min() noexcept {
+      static constexpr float min() noexcept {
 #if defined __CUDA_ARCH__
         return FLT_MIN;
 #else
@@ -97,21 +105,21 @@ namespace trng {
 #endif
       }
       TRNG_CUDA_ENABLE
-      static float max() noexcept {
+      static constexpr float max() noexcept {
 #if defined __CUDA_ARCH__
         return CUDART_MAX_NORMAL_F;
 #else
         return ::std::numeric_limits<float>::max();
 #endif
       }
-      static const int digits = ::std::numeric_limits<float>::digits;
-      static const int digits10 = ::std::numeric_limits<float>::digits10;
-      static const bool is_signed = ::std::numeric_limits<float>::is_signed;
-      static const bool is_integer = ::std::numeric_limits<float>::is_integer;
-      static const bool is_exact = ::std::numeric_limits<float>::is_exact;
-      static const int radix = ::std::numeric_limits<float>::radix;
+      static constexpr int digits = ::std::numeric_limits<float>::digits;
+      static constexpr int digits10 = ::std::numeric_limits<float>::digits10;
+      static constexpr bool is_signed = ::std::numeric_limits<float>::is_signed;
+      static constexpr bool is_integer = ::std::numeric_limits<float>::is_integer;
+      static constexpr bool is_exact = ::std::numeric_limits<float>::is_exact;
+      static constexpr int radix = ::std::numeric_limits<float>::radix;
       TRNG_CUDA_ENABLE
-      static float epsilon() noexcept {
+      static constexpr float epsilon() noexcept {
 #if defined __CUDA_ARCH__
         return FLT_EPSILON;
 #else
@@ -119,25 +127,25 @@ namespace trng {
 #endif
       }
       TRNG_CUDA_ENABLE
-      static float round_error() noexcept {
+      static constexpr float round_error() noexcept {
 #if defined __CUDA_ARCH__
         return 0.5f;
 #else
         return ::std::numeric_limits<float>::round_error();
 #endif
       }
-      static const int min_exponent = ::std::numeric_limits<float>::min_exponent;
-      static const int min_exponent10 = ::std::numeric_limits<float>::min_exponent10;
-      static const int max_exponent = ::std::numeric_limits<float>::max_exponent;
-      static const int max_exponent10 = ::std::numeric_limits<float>::max_exponent10;
-      static const bool has_infinity = ::std::numeric_limits<float>::has_infinity;
-      static const bool has_quiet_NaN = ::std::numeric_limits<float>::has_quiet_NaN;
-      static const bool has_signaling_NaN = ::std::numeric_limits<float>::has_signaling_NaN;
-      static const ::std::float_denorm_style has_denorm =
+      static constexpr int min_exponent = ::std::numeric_limits<float>::min_exponent;
+      static constexpr int min_exponent10 = ::std::numeric_limits<float>::min_exponent10;
+      static constexpr int max_exponent = ::std::numeric_limits<float>::max_exponent;
+      static constexpr int max_exponent10 = ::std::numeric_limits<float>::max_exponent10;
+      static constexpr bool has_infinity = ::std::numeric_limits<float>::has_infinity;
+      static constexpr bool has_quiet_NaN = ::std::numeric_limits<float>::has_quiet_NaN;
+      static constexpr bool has_signaling_NaN = ::std::numeric_limits<float>::has_signaling_NaN;
+      static constexpr ::std::float_denorm_style has_denorm =
           ::std::numeric_limits<float>::has_denorm;
-      static const bool has_denorm_loss = ::std::numeric_limits<float>::has_denorm_loss;
+      static constexpr bool has_denorm_loss = ::std::numeric_limits<float>::has_denorm_loss;
       TRNG_CUDA_ENABLE
-      static float infinity() noexcept {
+      static constexpr float infinity() noexcept {
 #if defined __CUDA_ARCH__
         return CUDART_INF_F;
 #else
@@ -145,7 +153,7 @@ namespace trng {
 #endif
       }
       TRNG_CUDA_ENABLE
-      static float quiet_NaN() noexcept {
+      static constexpr float quiet_NaN() noexcept {
 #if defined __CUDA_ARCH__
         return CUDART_NAN_F;
 #else
@@ -153,7 +161,7 @@ namespace trng {
 #endif
       }
       TRNG_CUDA_ENABLE
-      static float signaling_NaN() noexcept {
+      static constexpr float signaling_NaN() noexcept {
 #if defined __CUDA_ARCH__
         return CUDART_NAN_F;
 #else
@@ -161,19 +169,19 @@ namespace trng {
 #endif
       }
       TRNG_CUDA_ENABLE
-      static float denorm_min() noexcept {
+      static constexpr float denorm_min() noexcept {
 #if defined __CUDA_ARCH__
         return CUDART_MIN_DENORM_F;
 #else
         return ::std::numeric_limits<float>::denorm_min();
 #endif
       }
-      static const bool is_iec559 = ::std::numeric_limits<float>::is_iec559;
-      static const bool is_bounded = ::std::numeric_limits<float>::is_bounded;
-      static const bool is_modulo = ::std::numeric_limits<float>::is_modulo;
-      static const bool traps = ::std::numeric_limits<float>::traps;
-      static const bool tinyness_before = ::std::numeric_limits<float>::tinyness_before;
-      static const ::std::float_round_style round_style =
+      static constexpr bool is_iec559 = ::std::numeric_limits<float>::is_iec559;
+      static constexpr bool is_bounded = ::std::numeric_limits<float>::is_bounded;
+      static constexpr bool is_modulo = ::std::numeric_limits<float>::is_modulo;
+      static constexpr bool traps = ::std::numeric_limits<float>::traps;
+      static constexpr bool tinyness_before = ::std::numeric_limits<float>::tinyness_before;
+      static constexpr ::std::float_round_style round_style =
           ::std::numeric_limits<float>::round_style;
     };
 
@@ -182,9 +190,9 @@ namespace trng {
     template<>
     class numeric_limits<double> {
     public:
-      static const bool is_specialized = ::std::numeric_limits<double>::is_specialized;
+      static constexpr bool is_specialized = ::std::numeric_limits<double>::is_specialized;
       TRNG_CUDA_ENABLE
-      static double min() noexcept {
+      static constexpr double min() noexcept {
 #if defined __CUDA_ARCH__
 #if __CUDA_ARCH__ >= 130
         return DBL_MIN;
@@ -196,7 +204,7 @@ namespace trng {
 #endif
       }
       TRNG_CUDA_ENABLE
-      static double max() noexcept {
+      static constexpr double max() noexcept {
 #if defined __CUDA_ARCH__
 #if __CUDA_ARCH__ >= 130
         return DBL_MAX;
@@ -207,14 +215,14 @@ namespace trng {
         return ::std::numeric_limits<double>::max();
 #endif
       }
-      static const int digits = ::std::numeric_limits<double>::digits;
-      static const int digits10 = ::std::numeric_limits<double>::digits10;
-      static const bool is_signed = ::std::numeric_limits<double>::is_signed;
-      static const bool is_integer = ::std::numeric_limits<double>::is_integer;
-      static const bool is_exact = ::std::numeric_limits<double>::is_exact;
-      static const int radix = ::std::numeric_limits<double>::radix;
+      static constexpr int digits = ::std::numeric_limits<double>::digits;
+      static constexpr int digits10 = ::std::numeric_limits<double>::digits10;
+      static constexpr bool is_signed = ::std::numeric_limits<double>::is_signed;
+      static constexpr bool is_integer = ::std::numeric_limits<double>::is_integer;
+      static constexpr bool is_exact = ::std::numeric_limits<double>::is_exact;
+      static constexpr int radix = ::std::numeric_limits<double>::radix;
       TRNG_CUDA_ENABLE
-      static double epsilon() noexcept {
+      static constexpr double epsilon() noexcept {
 #if defined __CUDA_ARCH__
         return DBL_EPSILON;
 #else
@@ -222,25 +230,26 @@ namespace trng {
 #endif
       }
       TRNG_CUDA_ENABLE
-      static double round_error() noexcept {
+      static constexpr double round_error() noexcept {
 #if defined __CUDA_ARCH__
         return 0.5;
 #else
         return ::std::numeric_limits<double>::round_error();
 #endif
       }
-      static const int min_exponent = ::std::numeric_limits<double>::min_exponent;
-      static const int min_exponent10 = ::std::numeric_limits<double>::min_exponent10;
-      static const int max_exponent = ::std::numeric_limits<double>::max_exponent;
-      static const int max_exponent10 = ::std::numeric_limits<double>::max_exponent10;
-      static const bool has_infinity = ::std::numeric_limits<double>::has_infinity;
-      static const bool has_quiet_NaN = ::std::numeric_limits<double>::has_quiet_NaN;
-      static const bool has_signaling_NaN = ::std::numeric_limits<double>::has_signaling_NaN;
-      static const ::std::float_denorm_style has_denorm =
+      static constexpr int min_exponent = ::std::numeric_limits<double>::min_exponent;
+      static constexpr int min_exponent10 = ::std::numeric_limits<double>::min_exponent10;
+      static constexpr int max_exponent = ::std::numeric_limits<double>::max_exponent;
+      static constexpr int max_exponent10 = ::std::numeric_limits<double>::max_exponent10;
+      static constexpr bool has_infinity = ::std::numeric_limits<double>::has_infinity;
+      static constexpr bool has_quiet_NaN = ::std::numeric_limits<double>::has_quiet_NaN;
+      static constexpr bool has_signaling_NaN =
+          ::std::numeric_limits<double>::has_signaling_NaN;
+      static constexpr ::std::float_denorm_style has_denorm =
           ::std::numeric_limits<double>::has_denorm;
-      static const bool has_denorm_loss = ::std::numeric_limits<double>::has_denorm_loss;
+      static constexpr bool has_denorm_loss = ::std::numeric_limits<double>::has_denorm_loss;
       TRNG_CUDA_ENABLE
-      static double infinity() noexcept {
+      static constexpr double infinity() noexcept {
 #if defined __CUDA_ARCH__
 #if __CUDA_ARCH__ >= 130
         return CUDART_INF;
@@ -252,7 +261,7 @@ namespace trng {
 #endif
       }
       TRNG_CUDA_ENABLE
-      static double quiet_NaN() noexcept {
+      static constexpr double quiet_NaN() noexcept {
 #if defined __CUDA_ARCH__
 #if __CUDA_ARCH__ >= 130
         return CUDART_NAN;
@@ -264,7 +273,7 @@ namespace trng {
 #endif
       }
       TRNG_CUDA_ENABLE
-      static double signaling_NaN() noexcept {
+      static constexpr double signaling_NaN() noexcept {
 #if defined __CUDA_ARCH__
 #if __CUDA_ARCH__ >= 130
         return CUDART_NAN;
@@ -276,7 +285,7 @@ namespace trng {
 #endif
       }
       TRNG_CUDA_ENABLE
-      static double denorm_min() noexcept {
+      static constexpr double denorm_min() noexcept {
 #if defined __CUDA_ARCH__
 #if __CUDA_ARCH__ >= 130
         return CUDART_MIN_DENORM;
@@ -287,12 +296,12 @@ namespace trng {
         return ::std::numeric_limits<double>::denorm_min();
 #endif
       }
-      static const bool is_iec559 = ::std::numeric_limits<double>::is_iec559;
-      static const bool is_bounded = ::std::numeric_limits<double>::is_bounded;
-      static const bool is_modulo = ::std::numeric_limits<double>::is_modulo;
-      static const bool traps = ::std::numeric_limits<double>::traps;
-      static const bool tinyness_before = ::std::numeric_limits<double>::tinyness_before;
-      static const ::std::float_round_style round_style =
+      static constexpr bool is_iec559 = ::std::numeric_limits<double>::is_iec559;
+      static constexpr bool is_bounded = ::std::numeric_limits<double>::is_bounded;
+      static constexpr bool is_modulo = ::std::numeric_limits<double>::is_modulo;
+      static constexpr bool traps = ::std::numeric_limits<double>::traps;
+      static constexpr bool tinyness_before = ::std::numeric_limits<double>::tinyness_before;
+      static constexpr ::std::float_round_style round_style =
           ::std::numeric_limits<double>::round_style;
     };
 

--- a/inst/include/trng/linear_algebra.hpp
+++ b/inst/include/trng/linear_algebra.hpp
@@ -1,0 +1,287 @@
+// Copyright (c) 2000-2020, Heiko Bauke
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//   * Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//
+//   * Redistributions in binary form must reproduce the above
+//     copyright notice, this list of conditions and the following
+//     disclaimer in the documentation and/or other materials provided
+//     with the distribution.
+//
+//   * Neither the name of the copyright holder nor the names of its
+//     contributors may be used to endorse or promote products derived
+//     from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+// OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if !(defined TRNG_LINEAR_ALGEBRA_HPP)
+
+#define TRNG_LINEAR_ALGEBRA_HPP
+
+#include <vector>
+#include <cstddef>
+#include <ciso646>
+#include <iostream>
+#include <type_traits>
+#include <trng/utility.hpp>
+#include <trng/int_math.hpp>
+
+namespace trng {
+
+  template<typename T, std::size_t n>
+  class vector {
+    std::vector<T> data;
+
+  public:
+    using size_type = typename std::vector<T>::size_type;
+    using reference = typename std::vector<T>::reference;
+    using const_reference = typename std::vector<T>::const_reference;
+    using iterator = typename std::vector<T>::iterator;
+    using const_iterator = typename std::vector<T>::const_iterator;
+
+    vector() : data(n) {}
+
+    template<typename F>
+    explicit vector(F f) {
+      static_assert(trng::utility::is_same<T, decltype(f(0))>::value,
+                    "wrong return type of functor");
+      data.reserve(n);
+      for (size_type i{0}; i < n; ++i)
+        data.push_back(f(i));
+    }
+
+    template<typename... Ts>
+    explicit vector(Ts... t) : data{t...} {
+      static_assert(sizeof...(Ts) == n, "wrong number of arguments");
+      static_assert(trng::utility::is_same<T, Ts...>::value,
+                    "wrong type in constructor argument");
+    }
+
+    reference operator()(size_type i) { return data[i]; }
+    const_reference operator()(size_type i) const { return data[i]; }
+    constexpr size_type size() const { return n; }
+    iterator begin() { return data.begin(); }
+    const_iterator begin() const { return data.begin(); }
+    iterator end() { return data.end(); }
+    const_iterator end() const { return data.end(); }
+    bool operator==(const vector &other) const { return data == other.data; }
+    bool operator!=(const vector &other) const { return data != other.data; }
+  };
+
+
+  template<typename T, std::size_t n>
+  class matrix {
+    std::vector<T> data;
+
+  public:
+    using size_type = typename std::vector<T>::size_type;
+    using reference = typename std::vector<T>::reference;
+    using const_reference = typename std::vector<T>::const_reference;
+
+    matrix() : data(n * n) {}
+
+    template<typename F>
+    explicit matrix(F f) {
+      static_assert(trng::utility::is_same<T, decltype(f(0, 0))>::value,
+                    "wrong return type of functor");
+      data.reserve(n * n);
+      for (size_type i{0}; i < n; ++i)
+        for (size_type j{0}; j < n; ++j)
+          data.push_back(f(i, j));
+    }
+
+    template<typename... Ts>
+    explicit matrix(Ts... t) : data{t...} {
+      static_assert(sizeof...(Ts) == n * n, "wrong number of arguments");
+      static_assert(trng::utility::is_same<T, Ts...>::value,
+                    "wrong type in constructor argument");
+    }
+
+    reference operator()(size_type i, size_type j) { return data[j + i * n]; }
+    const_reference operator()(size_type i, size_type j) const { return data[j + i * n]; }
+    constexpr size_type size() const { return n; }
+    bool operator==(const matrix &other) const { return data == other.data; }
+    bool operator!=(const matrix &other) const { return data != other.data; }
+  };
+
+
+  template<typename T, std::size_t n>
+  vector<T, n> operator+(const vector<T, n> &a, const vector<T, n> &b) {
+    using size_type = typename vector<T, n>::size_type;
+    auto f = [&](size_type i) -> T { return a(i) + b(i); };
+    return vector<T, n>(f);
+  }
+
+
+  template<typename T, std::size_t n>
+  vector<T, n> operator*(T a, const vector<T, n> &b) {
+    using size_type = typename vector<T, n>::size_type;
+    auto f = [&](size_type i) -> T { return a * b(i); };
+    return vector<T, n>(f);
+  }
+
+
+  template<typename T, std::size_t n>
+  vector<T, n> operator*(const vector<T, n> &a, T b) {
+    using size_type = typename vector<T, n>::size_type;
+    auto f = [&](size_type i) -> T { return a(i) * b; };
+    return vector<T, n>(f);
+  }
+
+
+  template<typename T, std::size_t n>
+  matrix<T, n> operator+(const matrix<T, n> &a, const matrix<T, n> &b) {
+    using size_type = typename matrix<T, n>::size_type;
+    auto f = [&](size_type i, size_type j) -> T { return a(i, j) + b(i, j); };
+    return matrix<T, n>(f);
+  }
+
+
+  template<typename T, std::size_t n>
+  matrix<T, n> operator*(T a, const matrix<T, n> &b) {
+    using size_type = typename matrix<T, n>::size_type;
+    auto f = [&](size_type i, size_type j) -> T { return a * b(i, j); };
+    return matrix<T, n>(f);
+  }
+
+
+  template<typename T, std::size_t n>
+  matrix<T, n> operator*(const matrix<T, n> &a, T b) {
+    using size_type = typename matrix<T, n>::size_type;
+    auto f = [&](size_type i, size_type j) -> T { return a(i, j) * b; };
+    return matrix<T, n>(f);
+  }
+
+
+  template<typename T, std::size_t n>
+  vector<T, n> operator*(const matrix<T, n> &a, const vector<T, n> &b) {
+    using size_type = typename matrix<T, n>::size_type;
+    auto f = [&](size_type i) -> T {
+      T sum{};
+      for (size_type k{0}; k < n; ++k)
+        sum = sum + a(i, k) * b(k);
+      return sum;
+    };
+    return vector<T, n>(f);
+  }
+
+
+  template<typename T, std::size_t n>
+  matrix<T, n> operator*(const matrix<T, n> &a, const matrix<T, n> &b) {
+    using size_type = typename matrix<T, n>::size_type;
+    matrix<T, n> res;
+    const size_type step{32};
+    for (size_type j0{0}; j0 < n; j0 += step) {
+      for (size_type i{0}; i < n; ++i)
+        for (size_type j{j0}, j_end{utility::min(n, j0 + step)}; j < j_end; ++j)
+          res(i, j) = T{0};
+      for (size_type k0{0}; k0 < n; k0 += step) {
+        for (size_type i{0}; i < n; ++i)
+          for (size_type j{j0}, j_end{utility::min(n, j0 + step)}; j < j_end; ++j) {
+            T sum{0};
+            for (size_type k{k0}, k_end{utility::min(n, k0 + step)}; k < k_end; ++k)
+              sum = sum + a(i, k) * b(k, j);
+            res(i, j) = res(i, j) + sum;
+          }
+      }
+    }
+    return res;
+  }
+
+
+  template<typename T, std::size_t n>
+  matrix<T, n> power(const matrix<T, n> &a, unsigned long long m) {
+    using matrix_type = matrix<T, n>;
+    using size_type = typename matrix_type::size_type;
+
+    auto unit = [&](size_type i, size_type j) -> T { return i == j ? T{1} : T{0}; };
+    matrix_type res(unit);
+    matrix_type powers(a);
+    while (m > 0) {
+      if ((m & 1ull) == 1ull)
+        res = res * powers;
+      m >>= 1u;
+      if (m == 0)
+        break;
+      powers = powers * powers;
+    }
+    return res;
+  }
+
+
+  class GF2 {
+  public:
+    using value_type = std::uint8_t;
+
+  private:
+    std::uint8_t value{0};
+
+    explicit GF2(value_type v) : value{v} {}
+
+  public:
+    explicit GF2(bool v = false) : value(v ? 1 : 0) {}
+    explicit GF2(int v) : value(v != 0 ? 1 : 0) {}
+
+    explicit operator bool() { return value; }
+
+    friend bool operator==(const GF2 a, const GF2 b) { return a.value == b.value; }
+    friend bool operator!=(const GF2 a, const GF2 b) { return a.value != b.value; }
+
+    GF2 &operator+=(const GF2 other) {
+      value ^= other.value;
+      return *this;
+    }
+
+    GF2 &operator*=(const GF2 other) {
+      value &= other.value;
+      return *this;
+    }
+
+    friend GF2 operator+(const GF2 a, const GF2 b) {
+      return GF2{static_cast<value_type>(a.value ^ b.value)};
+    }
+
+    friend GF2 operator*(const GF2 a, const GF2 b) {
+      return GF2{static_cast<value_type>(a.value & b.value)};
+    }
+
+    template<typename T>
+    friend typename std::enable_if<std::is_integral<T>::value, T>::type operator*(const GF2 a,
+                                                                                  const T b) {
+      return a.value ? b : T{};
+    }
+
+    template<typename T>
+    friend typename std::enable_if<std::is_integral<T>::value, T>::type operator*(const T a,
+                                                                                  const GF2 b) {
+      return b.value ? a : T{};
+    }
+  };
+
+
+  template<typename CharT, typename Traits>
+  std::basic_ostream<CharT, Traits> &operator<<(std::basic_ostream<CharT, Traits> &os,
+                                                GF2 value) {
+    return os << static_cast<bool>(value);
+  }
+
+
+}  // namespace trng
+
+#endif

--- a/inst/include/trng/logistic_dist.hpp
+++ b/inst/include/trng/logistic_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -50,12 +50,11 @@ namespace trng {
   template<typename float_t = double>
   class logistic_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type theta_, eta_;
+      result_type theta_{1}, eta_{0};
 
     public:
       TRNG_CUDA_ENABLE
@@ -67,53 +66,53 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void eta(result_type eta_new) { eta_ = eta_new; }
       TRNG_CUDA_ENABLE
-      param_type() : theta_(1), eta_(0) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(result_type theta, result_type eta) : theta_(theta), eta_(eta) {}
+      param_type(result_type theta, result_type eta) : theta_{theta}, eta_{eta} {}
 
       friend class logistic_dist;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1)
-            << p.theta() << ' ' << p.eta() << ')';
+            << P.theta() << ' ' << P.eta() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t theta, eta;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> theta >> utility::delim(' ') >> eta >> utility::delim(')');
         if (in)
-          p = param_type(theta, eta);
+          P = param_type(theta, eta);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
     result_type icdf_(result_type x) const {
-      return p.eta() - math::ln((1 - x) / x) * p.theta();
+      return P.eta() - math::ln((1 - x) / x) * P.theta();
     }
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    logistic_dist(result_type theta, result_type eta) : p(theta, eta) {}
+    explicit logistic_dist(result_type theta, result_type eta) : P(theta, eta) {}
     TRNG_CUDA_ENABLE
-    explicit logistic_dist(const param_type &p) : p(p) {}
+    explicit logistic_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -123,8 +122,8 @@ namespace trng {
       return icdf_(utility::uniformoo<result_type>(r));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      logistic_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      logistic_dist g(P);
       return g(r);
     }
     // property methods
@@ -133,29 +132,29 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &P_new) { P = P_new; }
     TRNG_CUDA_ENABLE
-    result_type theta() const { return p.theta(); }
+    result_type theta() const { return P.theta(); }
     TRNG_CUDA_ENABLE
-    void theta(result_type theta_new) { p.theta(theta_new); }
+    void theta(result_type theta_new) { P.theta(theta_new); }
     TRNG_CUDA_ENABLE
-    result_type eta() const { return p.eta(); }
+    result_type eta() const { return P.eta(); }
     TRNG_CUDA_ENABLE
-    void eta(result_type eta_new) { p.eta(eta_new); }
+    void eta(result_type eta_new) { P.eta(eta_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
-      result_type t1(math::exp(-math::abs((x - p.eta()) / p.theta())));
-      result_type t2(1 + t1);
-      return t1 / (p.theta() * t2 * t2);
+      const result_type t1{(math::exp(-math::abs((x - P.eta()) / P.theta())))};
+      const result_type t2{1 + t1};
+      return t1 / (P.theta() * t2 * t2);
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
-      result_type t1(math::exp(-math::abs((x - p.eta()) / p.theta())));
-      return x >= p.eta() ? (1 / (1 + t1)) : (t1 / (1 + t1));
+      const result_type t1{math::exp(-math::abs((x - P.eta()) / P.theta()))};
+      return x >= P.eta() ? 1 / (1 + t1) : t1 / (1 + t1);
     }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
@@ -179,16 +178,16 @@ namespace trng {
   // EqualityComparable concept
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator==(
-      const typename logistic_dist<float_t>::param_type &p1,
-      const typename logistic_dist<float_t>::param_type &p2) {
-    return p1.theta() == p2.theta() and p1.eta() == p2.eta();
+      const typename logistic_dist<float_t>::param_type &P1,
+      const typename logistic_dist<float_t>::param_type &P2) {
+    return P1.theta() == P2.theta() and P1.eta() == P2.eta();
   }
 
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator!=(
-      const typename logistic_dist<float_t>::param_type &p1,
-      const typename logistic_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+      const typename logistic_dist<float_t>::param_type &P1,
+      const typename logistic_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -220,12 +219,12 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    logistic_dist<float_t> &g) {
-    typename logistic_dist<float_t>::param_type p;
+    typename logistic_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[logistic ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[logistic ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/lognormal_dist.hpp
+++ b/inst/include/trng/lognormal_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -52,12 +52,11 @@ namespace trng {
   template<typename float_t = double>
   class lognormal_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type mu_, sigma_;
+      result_type mu_{0}, sigma_{1};
 
     public:
       TRNG_CUDA_ENABLE
@@ -69,47 +68,47 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void sigma(result_type sigma_new) { sigma_ = sigma_new; }
       TRNG_CUDA_ENABLE
-      explicit param_type() : mu_(0), sigma_(1) {}
+      explicit param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(result_type mu, result_type sigma) : mu_(mu), sigma_(sigma) {}
+      explicit param_type(result_type mu, result_type sigma) : mu_{mu}, sigma_{sigma} {}
 
       friend class lognormal_dist;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << p.mu()
-            << ' ' << p.sigma() << ')';
+        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << P.mu()
+            << ' ' << P.sigma() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t mu, sigma;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> mu >> utility::delim(' ') >> sigma >> utility::delim(')');
         if (in)
-          p = param_type(mu, sigma);
+          P = param_type(mu, sigma);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    lognormal_dist(result_type mu, result_type sigma) : p(mu, sigma) {}
+    explicit lognormal_dist(result_type mu, result_type sigma) : P{mu, sigma} {}
     TRNG_CUDA_ENABLE
-    explicit lognormal_dist(const param_type &p) : p(p) {}
+    explicit lognormal_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -119,8 +118,8 @@ namespace trng {
       return icdf(utility::uniformoo<result_type>(r));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      lognormal_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      lognormal_dist g(P);
       return g(r);
     }
     // property methods
@@ -129,24 +128,24 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &P_new) { P = P_new; }
     TRNG_CUDA_ENABLE
-    result_type mu() const { return p.mu(); }
+    result_type mu() const { return P.mu(); }
     TRNG_CUDA_ENABLE
-    void mu(result_type mu_new) { p.mu(mu_new); }
+    void mu(result_type mu_new) { P.mu(mu_new); }
     TRNG_CUDA_ENABLE
-    result_type sigma() const { return p.sigma(); }
+    result_type sigma() const { return P.sigma(); }
     TRNG_CUDA_ENABLE
-    void sigma(result_type sigma_new) { p.sigma(sigma_new); }
+    void sigma(result_type sigma_new) { P.sigma(sigma_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
       if (x <= 0)
         return 0;
-      result_type t((math::ln(x) - p.mu()) / p.sigma());
-      return math::constants<result_type>::one_over_sqrt_2pi() / (x * p.sigma()) *
+      result_type t((math::ln(x) - P.mu()) / P.sigma());
+      return math::constants<result_type>::one_over_sqrt_2pi / (x * P.sigma()) *
              math::exp(-t * t / 2);
     }
     // cumulative density function
@@ -154,8 +153,7 @@ namespace trng {
     result_type cdf(result_type x) const {
       if (x <= 0)
         return 0;
-      return math::erfc(math::constants<result_type>::one_over_sqrt_2() *
-                        (p.mu() - math::ln(x)) / p.sigma()) /
+      return math::erfc(math::constants<result_type>::one_over_sqrt_2 * (P.mu() - math::ln(x)) / P.sigma()) /
              2;
     }
     // inverse cumulative density function
@@ -171,7 +169,7 @@ namespace trng {
         return 0;
       if (x == 1)
         return math::numeric_limits<result_type>::infinity();
-      return math::exp(math::inv_Phi(x) * p.sigma() + p.mu());
+      return math::exp(math::inv_Phi(x) * P.sigma() + P.mu());
     }
   };
 
@@ -180,16 +178,16 @@ namespace trng {
   // EqualityComparable concept
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator==(
-      const typename lognormal_dist<float_t>::param_type &p1,
-      const typename lognormal_dist<float_t>::param_type &p2) {
-    return p1.mu() == p2.mu() and p1.sigma() == p2.sigma();
+      const typename lognormal_dist<float_t>::param_type &P1,
+      const typename lognormal_dist<float_t>::param_type &P2) {
+    return P1.mu() == P2.mu() and P1.sigma() == P2.sigma();
   }
 
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator!=(
-      const typename lognormal_dist<float_t>::param_type &p1,
-      const typename lognormal_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+      const typename lognormal_dist<float_t>::param_type &P1,
+      const typename lognormal_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -221,12 +219,12 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    lognormal_dist<float_t> &g) {
-    typename lognormal_dist<float_t>::param_type p;
+    typename lognormal_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[lognormal ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[lognormal ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/math.hpp
+++ b/inst/include/trng/math.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -103,24 +103,13 @@ namespace trng {
     using ::std::acosh;
     using ::std::atanh;
 
-    inline float asech(float x) { return ::std::log((1.0f + ::std::sqrt(1.0f - x * x)) / x); }
-    inline double asech(double x) { return ::std::log((1.0 + ::std::sqrt(1.0 - x * x)) / x); }
-    inline long double asech(long double x) {
-      return ::std::log((1.0l + ::std::sqrt(1.0l - x * x)) / x);
-    }
+    inline float asech(float x) { return ::std::acosh(1.0f / x); }
+    inline double asech(double x) { return ::std::acosh(1.0 / x); }
+    inline long double asech(long double x) { return ::std::acosh(1.0l / x); }
 
-    inline float acsch(float x) {
-      const float t = 1.0f / x;
-      return ::std::log(t + ::std::sqrt(1.0f + t * t));
-    }
-    inline double acsch(double x) {
-      const double t = 1.0 / x;
-      return ::std::log(t + ::std::sqrt(1.0 + t * t));
-    }
-    inline long double acsch(long double x) {
-      const long double t = 1.0l / x;
-      return ::std::log(t + ::std::sqrt(1.0l + t * t));
-    }
+    inline float acsch(float x) { return ::std::asinh(1.0f / x); }
+    inline double acsch(double x) { return ::std::asinh(1.0 / x); }
+    inline long double acsch(long double x) { return ::std::asinh(1.0l / x); }
 
     inline float acoth(float x) { return 0.5f * ::std::log((x + 1.0f) / (x - 1.0f)); }
     inline double acoth(double x) { return 0.5 * ::std::log((x + 1.0) / (x - 1.0)); }
@@ -148,30 +137,6 @@ namespace trng {
     using ::std::frexp;
     using ::std::ldexp;
     using ::std::log;
-
-    template<typename T>
-    inline T log2_floor(T x) {
-      T y(0);
-      while (x > 0) {
-        x >>= 1;
-        ++y;
-      }
-      --y;
-      return y;
-    }
-
-    template<typename T>
-    inline T log2_ceil(T x) {
-      T y(log2_floor(x));
-      if ((T(1) << y) < x)
-        ++y;
-      return y;
-    }
-
-    template<typename T>
-    inline T pow2(T x) {
-      return T(1) << x;
-    }
 
     TRNG_CUDA_ENABLE
     inline float ln(float x) { return log(x); }
@@ -227,6 +192,10 @@ namespace trng {
       long double dummy;
       return ::std::modf(x, &dummy);
     }
+
+    using ::std::isfinite;
+    using ::std::isnan;
+    using ::std::isnormal;
 
   }  // namespace math
 

--- a/inst/include/trng/maxwell_dist.hpp
+++ b/inst/include/trng/maxwell_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -51,8 +51,7 @@ namespace trng {
   template<typename float_t = double>
   class maxwell_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
@@ -65,45 +64,45 @@ namespace trng {
       void theta(result_type theta_new) { theta_ = theta_new; }
       param_type() = default;
       TRNG_CUDA_ENABLE
-      explicit param_type(result_type theta) : theta_(theta) {}
+      explicit param_type(result_type theta) : theta_{theta} {}
 
       friend class maxwell_dist;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1)
-            << p.theta() << ')';
+            << P.theta() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t theta;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> theta >> utility::delim(')');
         if (in)
-          p = param_type(theta);
+          P = param_type(theta);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    explicit maxwell_dist(result_type theta) : p(theta) {}
+    explicit maxwell_dist(result_type theta) : P{theta} {}
     TRNG_CUDA_ENABLE
-    explicit maxwell_dist(const param_type &p) : p(p) {}
+    explicit maxwell_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -113,8 +112,8 @@ namespace trng {
       return icdf(utility::uniformoo<result_type>(r));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      maxwell_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      maxwell_dist g(P);
       return g(r);
     }
     // property methods
@@ -123,25 +122,25 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &P_new) { P = P_new; }
     TRNG_CUDA_ENABLE
-    result_type theta() const { return p.theta(); }
+    result_type theta() const { return P.theta(); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
-      result_type x2(x * x);
-      result_type t2(p.theta() * p.theta());
-      return math::constants<result_type>::sqrt_2_over_pi() * x2 * math::exp(-x2 / (2 * t2)) /
-             (t2 * p.theta());
+      const result_type x2{x * x};
+      const result_type t2{P.theta() * P.theta()};
+      return math::constants<result_type>::sqrt_2_over_pi * x2 * math::exp(-x2 / (2 * t2)) /
+             (t2 * P.theta());
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
-      return math::erf(x * math::constants<result_type>::one_over_sqrt_2() / p.theta()) -
-             math::constants<result_type>::sqrt_2_over_pi() * x *
-                 math::exp(-x * x / (2 * p.theta() * p.theta())) / (p.theta());
+      return math::erf(x * math::constants<result_type>::one_over_sqrt_2 / P.theta()) -
+             math::constants<result_type>::sqrt_2_over_pi * x *
+                 math::exp(-x * x / (2 * P.theta() * P.theta())) / (P.theta());
     }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
@@ -156,8 +155,8 @@ namespace trng {
         return math::numeric_limits<result_type>::infinity();
       if (x == 0)
         return 0;
-      result_type y(2 * p.theta() * math::constants<result_type>::sqrt_2_over_pi());
-      for (int i = 0; i < math::numeric_limits<result_type>::digits + 2; ++i) {
+      result_type y(2 * P.theta() * math::constants<result_type>::sqrt_2_over_pi);
+      for (int i{0}; i < math::numeric_limits<result_type>::digits + 2; ++i) {
         result_type y_old = y;
         y -= (cdf(y) - x) / pdf(y);
         if (math::abs(y / y_old - 1) < 4 * math::numeric_limits<result_type>::epsilon())
@@ -172,16 +171,16 @@ namespace trng {
   // EqualityComparable concept
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator==(
-      const typename maxwell_dist<float_t>::param_type &p1,
-      const typename maxwell_dist<float_t>::param_type &p2) {
-    return p1.theta() == p2.theta();
+      const typename maxwell_dist<float_t>::param_type &P1,
+      const typename maxwell_dist<float_t>::param_type &P2) {
+    return P1.theta() == P2.theta();
   }
 
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator!=(
-      const typename maxwell_dist<float_t>::param_type &p1,
-      const typename maxwell_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+      const typename maxwell_dist<float_t>::param_type &P1,
+      const typename maxwell_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -213,12 +212,12 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    maxwell_dist<float_t> &g) {
-    typename maxwell_dist<float_t>::param_type p;
+    typename maxwell_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[maxwell ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[maxwell ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/minstd.hpp
+++ b/inst/include/trng/minstd.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -35,17 +35,15 @@
 #define TRNG_MINSTD_HPP
 
 #include <trng/limits.hpp>
+#include <trng/utility.hpp>
+#include <trng/int_types.hpp>
 #include <climits>
 #include <stdexcept>
 #include <ostream>
 #include <istream>
-#include <trng/utility.hpp>
-#include <trng/int_types.hpp>
 #include <ciso646>
 
 namespace trng {
-
-  class minstd;
 
   class minstd {
   public:
@@ -54,22 +52,20 @@ namespace trng {
     result_type operator()();
 
   private:
-    static const result_type min_ = 1u;
-    static const result_type max_ = 2147483646u;
+    static constexpr result_type min_ = 1u;
+    static constexpr result_type max_ = 2147483646u;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class status_type;
-
     class status_type {
-      result_type r;
+      result_type r{1};
 
     public:
-      status_type() : r(1){};
-      explicit status_type(result_type r) : r(r){};
+      status_type() = default;
+      explicit status_type(result_type r) : r{r} {};
 
       friend class minstd;
 
@@ -107,7 +103,7 @@ namespace trng {
     explicit minstd(unsigned long);
 
     template<typename gen>
-    explicit minstd(gen &g) : S() {
+    explicit minstd(gen &g) {
       seed(g);
     }
 
@@ -166,8 +162,8 @@ namespace trng {
   // Inline and template methods
 
   inline void minstd::step() {
-    uint64_t t = S.r * 16807;
-    t = (t & 0x7fffffffu) + (t >> 31);
+    uint64_t t{S.r * 16807};
+    t = (t & 0x7fffffffu) + (t >> 31u);
     if (t >= 2147483647u)
       t -= 2147483647u;
     S.r = static_cast<result_type>(t);
@@ -180,7 +176,7 @@ namespace trng {
 
   inline void minstd::discard(unsigned long long n) {
     n %= minstd::max_ - minstd::min_;
-    for (unsigned long long i(0); i < n; ++i)
+    for (unsigned long long i{0}; i < n; ++i)
       step();
   }
 

--- a/inst/include/trng/mrg2.hpp
+++ b/inst/include/trng/mrg2.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,116 +34,38 @@
 
 #define TRNG_MRG2_HPP
 
-#include <ostream>
-#include <istream>
-#include <stdexcept>
 #include <trng/cuda.hpp>
 #include <trng/utility.hpp>
 #include <trng/int_types.hpp>
 #include <trng/int_math.hpp>
+#include <trng/mrg_parameter.hpp>
+#include <trng/mrg_status.hpp>
+#include <ostream>
+#include <istream>
+#include <stdexcept>
 #include <ciso646>
 
 namespace trng {
 
-  class mrg2;
-
   class mrg2 {
   public:
     // Uniform random number generator concept
-    typedef int32_t result_type;
+    using result_type = int32_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type modulus = 2147483647;
-    static const result_type min_ = 0;
-    static const result_type max_ = modulus - 1;
+    static constexpr result_type modulus = 2147483647;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = modulus - 1;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
-    class parameter_type {
-      result_type a1, a2;
-
-    public:
-      parameter_type() : a1(0), a2(0){};
-      parameter_type(result_type a1, result_type a2) : a1(a1), a2(a2){};
-
-      friend class mrg2;
-
-      // Equality comparable concept
-      friend bool operator==(const parameter_type &, const parameter_type &);
-      friend bool operator!=(const parameter_type &, const parameter_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const parameter_type &P) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << P.a1 << ' ' << P.a2 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, parameter_type &P) {
-        parameter_type P_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> P_new.a1 >> utility::delim(' ') >> P_new.a2 >>
-            utility::delim(')');
-        if (in)
-          P = P_new;
-        in.flags(flags);
-        return in;
-      }
-    };
-
-    class status_type {
-      result_type r1, r2;
-
-    public:
-      status_type() : r1(0), r2(1){};
-      status_type(result_type r1, result_type r2) : r1(r1), r2(r2){};
-
-      friend class mrg2;
-
-      // Equality comparable concept
-      friend bool operator==(const status_type &, const status_type &);
-      friend bool operator!=(const status_type &, const status_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const status_type &S) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << S.r1 << ' ' << S.r2 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, status_type &S) {
-        status_type S_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> S_new.r1 >> utility::delim(' ') >> S_new.r2 >>
-            utility::delim(')');
-        if (in)
-          S = S_new;
-        in.flags(flags);
-        return in;
-      }
-    };
+    using parameter_type = mrg_parameter<result_type, 2, mrg2>;
+    using status_type = mrg_status<result_type, 2, mrg2>;
 
     static const parameter_type LEcuyer1;
     static const parameter_type LEcuyer2;
@@ -152,7 +74,7 @@ namespace trng {
     explicit mrg2(parameter_type = LEcuyer1);
     explicit mrg2(unsigned long, parameter_type = LEcuyer1);
     template<typename gen>
-    explicit mrg2(gen &g, parameter_type P = LEcuyer1) : P(P), S() {
+    explicit mrg2(gen &g, parameter_type P = LEcuyer1) : P{P} {
       seed(g);
     }
 
@@ -160,10 +82,10 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      uint32_t r1 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      uint32_t r2 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      S.r1 = r1;
-      S.r2 = r2;
+      const uint32_t r1{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const uint32_t r2{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      S.r[0] = r1;
+      S.r[1] = r2;
     }
     void seed(result_type, result_type);
 
@@ -230,16 +152,16 @@ namespace trng {
 
   TRNG_CUDA_ENABLE
   inline void mrg2::step() {
-    uint64_t t(static_cast<uint64_t>(P.a1) * static_cast<uint64_t>(S.r1) +
-               static_cast<uint64_t>(P.a2) * static_cast<uint64_t>(S.r2));
-    S.r2 = S.r1;
-    S.r1 = int_math::modulo<modulus, 2>(t);
+    const uint64_t t{static_cast<uint64_t>(P.a[0]) * static_cast<uint64_t>(S.r[0]) +
+                     static_cast<uint64_t>(P.a[1]) * static_cast<uint64_t>(S.r[1])};
+    S.r[1] = S.r[0];
+    S.r[0] = int_math::modulo<modulus, 2>(t);
   }
 
   TRNG_CUDA_ENABLE
   inline mrg2::result_type mrg2::operator()() {
     step();
-    return S.r1;
+    return S.r[0];
   }
 
   TRNG_CUDA_ENABLE
@@ -256,13 +178,13 @@ namespace trng {
 #endif
     if (s > 1) {
       jump(n + 1);
-      result_type q0 = S.r1;
+      const result_type q0{S.r[0]};
       jump(s);
-      result_type q1 = S.r1;
+      const result_type q1{S.r[0]};
       jump(s);
-      result_type q2 = S.r1;
+      const result_type q2{S.r[0]};
       jump(s);
-      result_type q3 = S.r1;
+      const result_type q3{S.r[0]};
       result_type a[2], b[4];
       a[0] = q2;
       b[0] = q1;
@@ -271,82 +193,81 @@ namespace trng {
       b[2] = q2;
       b[3] = q1;
       int_math::gauss<2>(b, a, modulus);
-      P.a1 = a[0];
-      P.a2 = a[1];
-      S.r1 = q1;
-      S.r2 = q0;
-      for (int i = 0; i < 2; ++i)
+      P.a[0] = a[0];
+      P.a[1] = a[1];
+      S.r[0] = q1;
+      S.r[1] = q0;
+      for (int i{0}; i < 2; ++i)
         backward();
     }
   }
 
   TRNG_CUDA_ENABLE
   inline void mrg2::jump2(unsigned int s) {
-    result_type b[4], c[4], d[2], r[2];
-    result_type t1(P.a1), t2(P.a2);
-    b[0] = P.a1;
-    b[1] = P.a2;
+    result_type b[4], c[4]{};
+    b[0] = P.a[0];
+    b[1] = P.a[1];
     b[2] = 1;
     b[3] = 0;
-    for (unsigned int i(0); i < s; ++i)
-      if ((i & 1) == 0)
-        int_math::matrix_mult<2>(b, b, c, modulus);
-      else
-        int_math::matrix_mult<2>(c, c, b, modulus);
-    r[0] = S.r1;
-    r[1] = S.r2;
-    if ((s & 1) == 0)
+    for (unsigned int i{0}; i < s; ++i) {
+      int_math::matrix_mult<2>(b, b, c, modulus);
+      ++i;
+      if (not(i < s))
+        break;
+      int_math::matrix_mult<2>(c, c, b, modulus);
+    }
+    const result_type r[2]{S.r[0], S.r[1]};
+    result_type d[2];
+    if ((s & 1u) == 0)
       int_math::matrix_vec_mult<2>(b, r, d, modulus);
     else
       int_math::matrix_vec_mult<2>(c, r, d, modulus);
-    S.r1 = d[0];
-    S.r2 = d[1];
-    P.a1 = t1;
-    P.a2 = t2;
+    S.r[0] = d[0];
+    S.r[1] = d[1];
   }
 
   TRNG_CUDA_ENABLE
   inline void mrg2::jump(unsigned long long s) {
     if (s < 16) {
-      for (unsigned int i(0); i < s; ++i)
+      for (unsigned int i{0}; i < s; ++i)
         step();
     } else {
-      unsigned int i(0);
+      unsigned int i{0};
       while (s > 0) {
         if (s % 2 == 1)
           jump2(i);
         ++i;
-        s >>= 1;
+        s >>= 1u;
       }
     }
   }
 
   TRNG_CUDA_ENABLE
-  inline void mrg2::discard(unsigned long long n) { return jump(n); }
+  inline void mrg2::discard(unsigned long long n) { jump(n); }
 
   TRNG_CUDA_ENABLE
   inline void mrg2::backward() {
     result_type t;
-    if (P.a2 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    if (P.a[1] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a2, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[1], modulus))) %
           modulus);
-    } else if (P.a1 != 0) {
-      t = S.r2;
+    } else if (P.a[0] != 0) {
+      t = S.r[1];
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a1, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[0], modulus))) %
           modulus);
     } else
       t = 0;
-    S.r1 = S.r2;
-    S.r2 = t;
+    S.r[0] = S.r[1];
+    S.r[1] = t;
   }
 
 }  // namespace trng

--- a/inst/include/trng/mrg3.hpp
+++ b/inst/include/trng/mrg3.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,116 +34,38 @@
 
 #define TRNG_MRG3_HPP
 
-#include <ostream>
-#include <istream>
-#include <stdexcept>
 #include <trng/cuda.hpp>
 #include <trng/utility.hpp>
 #include <trng/int_types.hpp>
 #include <trng/int_math.hpp>
+#include <trng/mrg_parameter.hpp>
+#include <trng/mrg_status.hpp>
+#include <ostream>
+#include <istream>
+#include <stdexcept>
 #include <ciso646>
 
 namespace trng {
 
-  class mrg3;
-
   class mrg3 {
   public:
     // Uniform random number generator concept
-    typedef int32_t result_type;
+    using result_type = int32_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type modulus = 2147483647;
-    static const result_type min_ = 0;
-    static const result_type max_ = modulus - 1;
+    static constexpr result_type modulus = 2147483647;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = modulus - 1;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
-    class parameter_type {
-      result_type a1, a2, a3;
-
-    public:
-      parameter_type() : a1(0), a2(0), a3(0){};
-      parameter_type(result_type a1, result_type a2, result_type a3) : a1(a1), a2(a2), a3(a3){};
-
-      friend class mrg3;
-
-      // Equality comparable concept
-      friend bool operator==(const parameter_type &, const parameter_type &);
-      friend bool operator!=(const parameter_type &, const parameter_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const parameter_type &P) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << P.a1 << ' ' << P.a2 << ' ' << P.a3 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, parameter_type &P) {
-        parameter_type P_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> P_new.a1 >> utility::delim(' ') >> P_new.a2 >>
-            utility::delim(' ') >> P_new.a3 >> utility::delim(')');
-        if (in)
-          P = P_new;
-        in.flags(flags);
-        return in;
-      }
-    };
-
-    class status_type {
-      result_type r1, r2, r3;
-
-    public:
-      status_type() : r1(0), r2(1), r3(1){};
-      status_type(result_type r1, result_type r2, result_type r3) : r1(r1), r2(r2), r3(r3){};
-
-      friend class mrg3;
-
-      // Equality comparable concept
-      friend bool operator==(const status_type &, const status_type &);
-      friend bool operator!=(const status_type &, const status_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const status_type &S) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << S.r1 << ' ' << S.r2 << ' ' << S.r3 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, status_type &S) {
-        status_type S_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> S_new.r1 >> utility::delim(' ') >> S_new.r2 >>
-            utility::delim(' ') >> S_new.r3 >> utility::delim(')');
-        if (in)
-          S = S_new;
-        in.flags(flags);
-        return in;
-      }
-    };
+    using parameter_type = mrg_parameter<result_type, 3, mrg3>;
+    using status_type = mrg_status<result_type, 3, mrg3>;
 
     static const parameter_type LEcuyer1;
     static const parameter_type LEcuyer2;
@@ -153,7 +75,7 @@ namespace trng {
     explicit mrg3(parameter_type = LEcuyer1);
     explicit mrg3(unsigned long, parameter_type = LEcuyer1);
     template<typename gen>
-    explicit mrg3(gen &g, parameter_type P = LEcuyer1) : P(P), S() {
+    explicit mrg3(gen &g, parameter_type P = LEcuyer1) : P{P} {
       seed(g);
     }
 
@@ -161,12 +83,12 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      result_type r1 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r2 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r3 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      S.r1 = r1;
-      S.r2 = r2;
-      S.r3 = r3;
+      const result_type r1{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r2{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r3{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      S.r[0] = r1;
+      S.r[1] = r2;
+      S.r[2] = r3;
     }
     void seed(result_type, result_type, result_type);
 
@@ -233,18 +155,18 @@ namespace trng {
 
   TRNG_CUDA_ENABLE
   inline void mrg3::step() {
-    uint64_t t(static_cast<uint64_t>(P.a1) * static_cast<uint64_t>(S.r1) +
-               static_cast<uint64_t>(P.a2) * static_cast<uint64_t>(S.r2) +
-               static_cast<uint64_t>(P.a3) * static_cast<uint64_t>(S.r3));
-    S.r3 = S.r2;
-    S.r2 = S.r1;
-    S.r1 = int_math::modulo<modulus, 3>(t);
+    const uint64_t t{static_cast<uint64_t>(P.a[0]) * static_cast<uint64_t>(S.r[0]) +
+                     static_cast<uint64_t>(P.a[1]) * static_cast<uint64_t>(S.r[1]) +
+                     static_cast<uint64_t>(P.a[2]) * static_cast<uint64_t>(S.r[2])};
+    S.r[2] = S.r[1];
+    S.r[1] = S.r[0];
+    S.r[0] = int_math::modulo<modulus, 3>(t);
   }
 
   TRNG_CUDA_ENABLE
   inline mrg3::result_type mrg3::operator()() {
     step();
-    return S.r1;
+    return S.r[0];
   }
 
   TRNG_CUDA_ENABLE
@@ -261,17 +183,17 @@ namespace trng {
 #endif
     if (s > 1) {
       jump(n + 1);
-      int32_t q0 = S.r1;
+      const int32_t q0{S.r[0]};
       jump(s);
-      int32_t q1 = S.r1;
+      const int32_t q1{S.r[0]};
       jump(s);
-      int32_t q2 = S.r1;
+      const int32_t q2{S.r[0]};
       jump(s);
-      int32_t q3 = S.r1;
+      const int32_t q3{S.r[0]};
       jump(s);
-      int32_t q4 = S.r1;
+      const int32_t q4{S.r[0]};
       jump(s);
-      int32_t q5 = S.r1;
+      const int32_t q5{S.r[0]};
       int32_t a[3], b[9];
       a[0] = q3;
       b[0] = q2;
@@ -286,54 +208,51 @@ namespace trng {
       b[7] = q3;
       b[8] = q2;
       int_math::gauss<3>(b, a, modulus);
-      P.a1 = a[0];
-      P.a2 = a[1];
-      P.a3 = a[2];
-      S.r1 = q2;
-      S.r2 = q1;
-      S.r3 = q0;
-      for (int i = 0; i < 3; ++i)
+      P.a[0] = a[0];
+      P.a[1] = a[1];
+      P.a[2] = a[2];
+      S.r[0] = q2;
+      S.r[1] = q1;
+      S.r[2] = q0;
+      for (int i{0}; i < 3; ++i)
         backward();
     }
   }
 
   TRNG_CUDA_ENABLE
   inline void mrg3::jump2(unsigned int s) {
-    int32_t b[9], c[9], d[3], r[3];
-    int32_t t1(P.a1), t2(P.a2), t3(P.a3);
-    b[0] = P.a1;
-    b[1] = P.a2;
-    b[2] = P.a3;
+    result_type b[9], c[9]{};
+    b[0] = P.a[0];
+    b[1] = P.a[1];
+    b[2] = P.a[2];
     b[3] = 1;
     b[4] = 0;
     b[5] = 0;
     b[6] = 0;
     b[7] = 1;
     b[8] = 0;
-    for (unsigned int i(0); i < s; ++i)
-      if ((i & 1) == 0)
-        int_math::matrix_mult<3>(b, b, c, modulus);
-      else
-        int_math::matrix_mult<3>(c, c, b, modulus);
-    r[0] = S.r1;
-    r[1] = S.r2;
-    r[2] = S.r3;
-    if ((s & 1) == 0)
+    for (unsigned int i{0}; i < s; ++i) {
+      int_math::matrix_mult<3>(b, b, c, modulus);
+      ++i;
+      if (not(i < s))
+        break;
+      int_math::matrix_mult<3>(c, c, b, modulus);
+    }
+    const result_type r[3]{S.r[0], S.r[1], S.r[2]};
+    result_type d[3];
+    if ((s & 1u) == 0)
       int_math::matrix_vec_mult<3>(b, r, d, modulus);
     else
       int_math::matrix_vec_mult<3>(c, r, d, modulus);
-    S.r1 = d[0];
-    S.r2 = d[1];
-    S.r3 = d[2];
-    P.a1 = t1;
-    P.a2 = t2;
-    P.a3 = t3;
+    S.r[0] = d[0];
+    S.r[1] = d[1];
+    S.r[2] = d[2];
   }
 
   TRNG_CUDA_ENABLE
   inline void mrg3::jump(unsigned long long s) {
     if (s < 16) {
-      for (unsigned int i(0); i < s; ++i)
+      for (unsigned int i{0}; i < s; ++i)
         step();
     } else {
       unsigned int i(0);
@@ -341,52 +260,52 @@ namespace trng {
         if (s % 2 == 1)
           jump2(i);
         ++i;
-        s >>= 1;
+        s >>= 1u;
       }
     }
   }
 
   TRNG_CUDA_ENABLE
-  inline void mrg3::discard(unsigned long long n) { return jump(n); }
+  inline void mrg3::discard(unsigned long long n) { jump(n); }
 
   TRNG_CUDA_ENABLE
   inline void mrg3::backward() {
     result_type t;
-    if (P.a3 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    if (P.a[2] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a3, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[2], modulus))) %
           modulus);
-    } else if (P.a2 != 0) {
-      t = S.r2;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+    } else if (P.a[1] != 0) {
+      t = S.r[1];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a2, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[1], modulus))) %
           modulus);
-    } else if (P.a1 != 0) {
-      t = S.r3;
+    } else if (P.a[0] != 0) {
+      t = S.r[2];
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a1, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[0], modulus))) %
           modulus);
     } else
       t = 0;
-    S.r1 = S.r2;
-    S.r2 = S.r3;
-    S.r3 = t;
+    S.r[0] = S.r[1];
+    S.r[1] = S.r[2];
+    S.r[2] = t;
   }
 
 }  // namespace trng

--- a/inst/include/trng/mrg3s.hpp
+++ b/inst/include/trng/mrg3s.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,116 +34,38 @@
 
 #define TRNG_MRG3S_HPP
 
-#include <ostream>
-#include <istream>
-#include <stdexcept>
 #include <trng/cuda.hpp>
 #include <trng/utility.hpp>
 #include <trng/int_types.hpp>
 #include <trng/int_math.hpp>
+#include <trng/mrg_parameter.hpp>
+#include <trng/mrg_status.hpp>
+#include <ostream>
+#include <istream>
+#include <stdexcept>
 #include <ciso646>
 
 namespace trng {
 
-  class mrg3s;
-
   class mrg3s {
   public:
     // Uniform random number generator concept
-    typedef int32_t result_type;
+    using result_type = int32_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type modulus = 2147462579;  // 2^31-21069
-    static const result_type min_ = 0;
-    static const result_type max_ = modulus - 1;
+    static constexpr result_type modulus = 2147462579;  // 2^31-21069
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = modulus - 1;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
-    class parameter_type {
-      result_type a1, a2, a3;
-
-    public:
-      parameter_type() : a1(0), a2(0), a3(0){};
-      parameter_type(result_type a1, result_type a2, result_type a3) : a1(a1), a2(a2), a3(a3){};
-
-      friend class mrg3s;
-
-      // Equality comparable concept
-      friend bool operator==(const parameter_type &, const parameter_type &);
-      friend bool operator!=(const parameter_type &, const parameter_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const parameter_type &P) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << P.a1 << ' ' << P.a2 << ' ' << P.a3 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, parameter_type &P) {
-        parameter_type P_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> P_new.a1 >> utility::delim(' ') >> P_new.a2 >>
-            utility::delim(' ') >> P_new.a3 >> utility::delim(')');
-        if (in)
-          P = P_new;
-        in.flags(flags);
-        return in;
-      }
-    };
-
-    class status_type {
-      result_type r1, r2, r3;
-
-    public:
-      status_type() : r1(0), r2(1), r3(1){};
-      status_type(result_type r1, result_type r2, result_type r3) : r1(r1), r2(r2), r3(r3){};
-
-      friend class mrg3s;
-
-      // Equality comparable concept
-      friend bool operator==(const status_type &, const status_type &);
-      friend bool operator!=(const status_type &, const status_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const status_type &S) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << S.r1 << ' ' << S.r2 << ' ' << S.r3 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, status_type &S) {
-        status_type S_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> S_new.r1 >> utility::delim(' ') >> S_new.r2 >>
-            utility::delim(' ') >> S_new.r3 >> utility::delim(')');
-        if (in)
-          S = S_new;
-        in.flags(flags);
-        return in;
-      }
-    };
+    using parameter_type = mrg_parameter<result_type, 3, mrg3s>;
+    using status_type = mrg_status<result_type, 3, mrg3s>;
 
     static const parameter_type trng0;
     static const parameter_type trng1;
@@ -152,7 +74,7 @@ namespace trng {
     explicit mrg3s(parameter_type = trng0);
     explicit mrg3s(unsigned long, parameter_type = trng0);
     template<typename gen>
-    explicit mrg3s(gen &g, parameter_type P = trng0) : P(P), S() {
+    explicit mrg3s(gen &g, parameter_type P = trng0) : P{P} {
       seed(g);
     }
 
@@ -160,12 +82,12 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      result_type r1 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r2 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r3 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      S.r1 = r1;
-      S.r2 = r2;
-      S.r3 = r3;
+      const result_type r1{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r2{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r3{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      S.r[0] = r1;
+      S.r[1] = r2;
+      S.r[2] = r3;
     }
     void seed(result_type, result_type, result_type);
 
@@ -232,18 +154,18 @@ namespace trng {
 
   TRNG_CUDA_ENABLE
   inline void mrg3s::step() {
-    uint64_t t(static_cast<uint64_t>(P.a1) * static_cast<uint64_t>(S.r1) +
-               static_cast<uint64_t>(P.a2) * static_cast<uint64_t>(S.r2) +
-               static_cast<uint64_t>(P.a3) * static_cast<uint64_t>(S.r3));
-    S.r3 = S.r2;
-    S.r2 = S.r1;
-    S.r1 = int_math::modulo<modulus, 3>(t);
+    const uint64_t t{static_cast<uint64_t>(P.a[0]) * static_cast<uint64_t>(S.r[0]) +
+                     static_cast<uint64_t>(P.a[1]) * static_cast<uint64_t>(S.r[1]) +
+                     static_cast<uint64_t>(P.a[2]) * static_cast<uint64_t>(S.r[2])};
+    S.r[2] = S.r[1];
+    S.r[1] = S.r[0];
+    S.r[0] = int_math::modulo<modulus, 3>(t);
   }
 
   TRNG_CUDA_ENABLE
   inline mrg3s::result_type mrg3s::operator()() {
     step();
-    return S.r1;
+    return S.r[0];
   }
 
   TRNG_CUDA_ENABLE
@@ -260,17 +182,17 @@ namespace trng {
 #endif
     if (s > 1) {
       jump(n + 1);
-      int32_t q0 = S.r1;
+      const int32_t q0{S.r[0]};
       jump(s);
-      int32_t q1 = S.r1;
+      const int32_t q1{S.r[0]};
       jump(s);
-      int32_t q2 = S.r1;
+      const int32_t q2{S.r[0]};
       jump(s);
-      int32_t q3 = S.r1;
+      const int32_t q3{S.r[0]};
       jump(s);
-      int32_t q4 = S.r1;
+      const int32_t q4{S.r[0]};
       jump(s);
-      int32_t q5 = S.r1;
+      const int32_t q5{S.r[0]};
       int32_t a[3], b[9];
       a[0] = q3;
       b[0] = q2;
@@ -285,107 +207,104 @@ namespace trng {
       b[7] = q3;
       b[8] = q2;
       int_math::gauss<3>(b, a, modulus);
-      P.a1 = a[0];
-      P.a2 = a[1];
-      P.a3 = a[2];
-      S.r1 = q2;
-      S.r2 = q1;
-      S.r3 = q0;
-      for (int i = 0; i < 3; ++i)
+      P.a[0] = a[0];
+      P.a[1] = a[1];
+      P.a[2] = a[2];
+      S.r[0] = q2;
+      S.r[1] = q1;
+      S.r[2] = q0;
+      for (int i{0}; i < 3; ++i)
         backward();
     }
   }
 
   TRNG_CUDA_ENABLE
   inline void mrg3s::jump2(unsigned int s) {
-    int32_t b[9], c[9], d[3], r[3];
-    int32_t t1(P.a1), t2(P.a2), t3(P.a3);
-    b[0] = P.a1;
-    b[1] = P.a2;
-    b[2] = P.a3;
+    result_type b[9], c[9]{};
+    b[0] = P.a[0];
+    b[1] = P.a[1];
+    b[2] = P.a[2];
     b[3] = 1;
     b[4] = 0;
     b[5] = 0;
     b[6] = 0;
     b[7] = 1;
     b[8] = 0;
-    for (unsigned int i(0); i < s; ++i)
-      if ((i & 1) == 0)
-        int_math::matrix_mult<3>(b, b, c, modulus);
-      else
-        int_math::matrix_mult<3>(c, c, b, modulus);
-    r[0] = S.r1;
-    r[1] = S.r2;
-    r[2] = S.r3;
-    if ((s & 1) == 0)
+    for (unsigned int i{0}; i < s; ++i) {
+      int_math::matrix_mult<3>(b, b, c, modulus);
+      ++i;
+      if (not(i < s))
+        break;
+      int_math::matrix_mult<3>(c, c, b, modulus);
+    }
+    const result_type r[3]{S.r[0], S.r[1], S.r[2]};
+    result_type d[3];
+    if ((s & 1u) == 0)
       int_math::matrix_vec_mult<3>(b, r, d, modulus);
     else
       int_math::matrix_vec_mult<3>(c, r, d, modulus);
-    S.r1 = d[0];
-    S.r2 = d[1];
-    S.r3 = d[2];
-    P.a1 = t1;
-    P.a2 = t2;
-    P.a3 = t3;
+    S.r[0] = d[0];
+    S.r[1] = d[1];
+    S.r[2] = d[2];
   }
 
   TRNG_CUDA_ENABLE
   inline void mrg3s::jump(unsigned long long s) {
     if (s < 16) {
-      for (unsigned int i(0); i < s; ++i)
+      for (unsigned int i{0}; i < s; ++i)
         step();
     } else {
-      unsigned int i(0);
+      unsigned int i{0};
       while (s > 0) {
         if (s % 2 == 1)
           jump2(i);
         ++i;
-        s >>= 1;
+        s >>= 1u;
       }
     }
   }
 
   TRNG_CUDA_ENABLE
-  inline void mrg3s::discard(unsigned long long n) { return jump(n); }
+  inline void mrg3s::discard(unsigned long long n) { jump(n); }
 
   TRNG_CUDA_ENABLE
   inline void mrg3s::backward() {
     result_type t;
-    if (P.a3 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    if (P.a[2] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a3, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[2], modulus))) %
           modulus);
-    } else if (P.a2 != 0) {
-      t = S.r2;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+    } else if (P.a[1] != 0) {
+      t = S.r[1];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a2, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[1], modulus))) %
           modulus);
-    } else if (P.a1 != 0) {
-      t = S.r3;
+    } else if (P.a[0] != 0) {
+      t = S.r[2];
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a1, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[0], modulus))) %
           modulus);
     } else
       t = 0;
-    S.r1 = S.r2;
-    S.r2 = S.r3;
-    S.r3 = t;
+    S.r[0] = S.r[1];
+    S.r[1] = S.r[2];
+    S.r[2] = t;
   }
 
 }  // namespace trng

--- a/inst/include/trng/mrg4.hpp
+++ b/inst/include/trng/mrg4.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,13 +34,15 @@
 
 #define TRNG_MRG4_HPP
 
-#include <ostream>
-#include <istream>
-#include <stdexcept>
 #include <trng/cuda.hpp>
 #include <trng/utility.hpp>
 #include <trng/int_types.hpp>
 #include <trng/int_math.hpp>
+#include <trng/mrg_parameter.hpp>
+#include <trng/mrg_status.hpp>
+#include <ostream>
+#include <istream>
+#include <stdexcept>
 #include <ciso646>
 
 namespace trng {
@@ -50,104 +52,22 @@ namespace trng {
   class mrg4 {
   public:
     // Uniform random number generator concept
-    typedef int32_t result_type;
+    using result_type = int32_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type modulus = 2147483647;
-    static const result_type min_ = 0;
-    static const result_type max_ = modulus - 1;
+    static constexpr result_type modulus = 2147483647;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = modulus - 1;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
-    class parameter_type {
-      result_type a1, a2, a3, a4;
-
-    public:
-      parameter_type() : a1(0), a2(0), a3(0), a4(0){};
-      parameter_type(result_type a1, result_type a2, result_type a3, result_type a4)
-          : a1(a1), a2(a2), a3(a3), a4(a4){};
-
-      friend class mrg4;
-
-      // Equality comparable concept
-      friend bool operator==(const parameter_type &, const parameter_type &);
-      friend bool operator!=(const parameter_type &, const parameter_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const parameter_type &P) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << P.a1 << ' ' << P.a2 << ' ' << P.a3 << ' ' << P.a4 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, parameter_type &P) {
-        parameter_type P_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> P_new.a1 >> utility::delim(' ') >> P_new.a2 >>
-            utility::delim(' ') >> P_new.a3 >> utility::delim(' ') >> P_new.a4 >>
-            utility::delim(')');
-        if (in)
-          P = P_new;
-        in.flags(flags);
-        return in;
-      }
-    };
-
-    class status_type {
-      result_type r1, r2, r3, r4;
-
-    public:
-      status_type() : r1(0), r2(1), r3(1), r4(1){};
-      status_type(result_type r1, result_type r2, result_type r3, result_type r4)
-          : r1(r1), r2(r2), r3(r3), r4(r4){};
-
-      friend class mrg4;
-
-      // Equality comparable concept
-      friend bool operator==(const status_type &, const status_type &);
-      friend bool operator!=(const status_type &, const status_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const status_type &S) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << S.r1 << ' ' << S.r2 << ' ' << S.r3 << ' ' << S.r4 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, status_type &S) {
-        status_type S_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> S_new.r1 >> utility::delim(' ') >> S_new.r2 >>
-            utility::delim(' ') >> S_new.r3 >> utility::delim(' ') >> S_new.r4 >>
-            utility::delim(')');
-        if (in)
-          S = S_new;
-        in.flags(flags);
-        return in;
-      }
-    };
+    using parameter_type = mrg_parameter<result_type, 4, mrg4>;
+    using status_type = mrg_status<result_type, 4, mrg4>;
 
     static const parameter_type LEcuyer1;
     static const parameter_type LEcuyer2;
@@ -156,7 +76,7 @@ namespace trng {
     explicit mrg4(parameter_type = LEcuyer1);
     explicit mrg4(unsigned long, parameter_type = LEcuyer1);
     template<typename gen>
-    explicit mrg4(gen &g, parameter_type P = LEcuyer1) : P(P), S() {
+    explicit mrg4(gen &g, parameter_type P = LEcuyer1) : P{P} {
       seed(g);
     }
 
@@ -164,14 +84,14 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      result_type r1 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r2 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r3 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r4 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      S.r1 = r1;
-      S.r2 = r2;
-      S.r3 = r3;
-      S.r4 = r4;
+      const result_type r1{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r2{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r3{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r4{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      S.r[0] = r1;
+      S.r[1] = r2;
+      S.r[2] = r3;
+      S.r[3] = r4;
     }
     void seed(result_type, result_type, result_type, result_type);
 
@@ -238,20 +158,20 @@ namespace trng {
 
   TRNG_CUDA_ENABLE
   inline void mrg4::step() {
-    uint64_t t(static_cast<uint64_t>(P.a1) * static_cast<uint64_t>(S.r1) +
-               static_cast<uint64_t>(P.a2) * static_cast<uint64_t>(S.r2) +
-               static_cast<uint64_t>(P.a3) * static_cast<uint64_t>(S.r3) +
-               static_cast<uint64_t>(P.a4) * static_cast<uint64_t>(S.r4));
-    S.r4 = S.r3;
-    S.r3 = S.r2;
-    S.r2 = S.r1;
-    S.r1 = int_math::modulo<modulus, 4>(t);
+    const uint64_t t{static_cast<uint64_t>(P.a[0]) * static_cast<uint64_t>(S.r[0]) +
+                     static_cast<uint64_t>(P.a[1]) * static_cast<uint64_t>(S.r[1]) +
+                     static_cast<uint64_t>(P.a[2]) * static_cast<uint64_t>(S.r[2]) +
+                     static_cast<uint64_t>(P.a[3]) * static_cast<uint64_t>(S.r[3])};
+    S.r[3] = S.r[2];
+    S.r[2] = S.r[1];
+    S.r[1] = S.r[0];
+    S.r[0] = int_math::modulo<modulus, 4>(t);
   }
 
   TRNG_CUDA_ENABLE
   inline mrg4::result_type mrg4::operator()() {
     step();
-    return S.r1;
+    return S.r[0];
   }
 
   TRNG_CUDA_ENABLE
@@ -268,21 +188,21 @@ namespace trng {
 #endif
     if (s > 1) {
       jump(n + 1);
-      int32_t q0 = S.r1;
+      const int32_t q0{S.r[0]};
       jump(s);
-      int32_t q1 = S.r1;
+      const int32_t q1{S.r[0]};
       jump(s);
-      int32_t q2 = S.r1;
+      const int32_t q2{S.r[0]};
       jump(s);
-      int32_t q3 = S.r1;
+      const int32_t q3{S.r[0]};
       jump(s);
-      int32_t q4 = S.r1;
+      const int32_t q4{S.r[0]};
       jump(s);
-      int32_t q5 = S.r1;
+      const int32_t q5{S.r[0]};
       jump(s);
-      int32_t q6 = S.r1;
+      const int32_t q6{S.r[0]};
       jump(s);
-      int32_t q7 = S.r1;
+      const int32_t q7{S.r[0]};
       int32_t a[4], b[16];
       a[0] = q4;
       b[0] = q3;
@@ -305,27 +225,26 @@ namespace trng {
       b[14] = q4;
       b[15] = q3;
       int_math::gauss<4>(b, a, modulus);
-      P.a1 = a[0];
-      P.a2 = a[1];
-      P.a3 = a[2];
-      P.a4 = a[3];
-      S.r1 = q3;
-      S.r2 = q2;
-      S.r3 = q1;
-      S.r4 = q0;
-      for (int i = 0; i < 4; ++i)
+      P.a[0] = a[0];
+      P.a[1] = a[1];
+      P.a[2] = a[2];
+      P.a[3] = a[3];
+      S.r[0] = q3;
+      S.r[1] = q2;
+      S.r[2] = q1;
+      S.r[3] = q0;
+      for (int i{0}; i < 4; ++i)
         backward();
     }
   }
 
   TRNG_CUDA_ENABLE
   inline void mrg4::jump2(unsigned int s) {
-    int32_t b[16], c[16], d[4], r[4];
-    int32_t t1(P.a1), t2(P.a2), t3(P.a3), t4(P.a4);
-    b[0] = P.a1;
-    b[1] = P.a2;
-    b[2] = P.a3;
-    b[3] = P.a4;
+    result_type b[16], c[16]{};
+    b[0] = P.a[0];
+    b[1] = P.a[1];
+    b[2] = P.a[2];
+    b[3] = P.a[3];
     b[4] = 1;
     b[5] = 0;
     b[6] = 0;
@@ -338,33 +257,29 @@ namespace trng {
     b[13] = 0;
     b[14] = 1;
     b[15] = 0;
-    for (unsigned int i(0); i < s; ++i)
-      if ((i & 1) == 0)
-        int_math::matrix_mult<4>(b, b, c, modulus);
-      else
-        int_math::matrix_mult<4>(c, c, b, modulus);
-    r[0] = S.r1;
-    r[1] = S.r2;
-    r[2] = S.r3;
-    r[3] = S.r4;
-    if ((s & 1) == 0)
+    for (unsigned int i{0}; i < s; ++i) {
+      int_math::matrix_mult<4>(b, b, c, modulus);
+      ++i;
+      if (not(i < s))
+        break;
+      int_math::matrix_mult<4>(c, c, b, modulus);
+    }
+    const result_type r[4]{S.r[0], S.r[1], S.r[2], S.r[3]};
+    result_type d[4];
+    if ((s & 1u) == 0)
       int_math::matrix_vec_mult<4>(b, r, d, modulus);
     else
       int_math::matrix_vec_mult<4>(c, r, d, modulus);
-    S.r1 = d[0];
-    S.r2 = d[1];
-    S.r3 = d[2];
-    S.r4 = d[3];
-    P.a1 = t1;
-    P.a2 = t2;
-    P.a3 = t3;
-    P.a4 = t4;
+    S.r[0] = d[0];
+    S.r[1] = d[1];
+    S.r[2] = d[2];
+    S.r[3] = d[3];
   }
 
   TRNG_CUDA_ENABLE
   inline void mrg4::jump(unsigned long long s) {
     if (s < 16) {
-      for (unsigned int i(0); i < s; ++i)
+      for (unsigned int i{0}; i < s; ++i)
         step();
     } else {
       unsigned int i(0);
@@ -372,71 +287,71 @@ namespace trng {
         if (s % 2 == 1)
           jump2(i);
         ++i;
-        s >>= 1;
+        s >>= 1u;
       }
     }
   }
 
   TRNG_CUDA_ENABLE
-  inline void mrg4::discard(unsigned long long n) { return jump(n); }
+  inline void mrg4::discard(unsigned long long n) { jump(n); }
 
   TRNG_CUDA_ENABLE
   inline void mrg4::backward() {
     result_type t;
-    if (P.a4 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    if (P.a[3] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a3) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[2]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a4, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[3], modulus))) %
           modulus);
-    } else if (P.a3 != 0) {
-      t = S.r2;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+    } else if (P.a[2] != 0) {
+      t = S.r[1];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a3, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[2], modulus))) %
           modulus);
-    } else if (P.a2 != 0) {
-      t = S.r3;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+    } else if (P.a[1] != 0) {
+      t = S.r[2];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a2, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[1], modulus))) %
           modulus);
-    } else if (P.a1 != 0) {
-      t = S.r4;
+    } else if (P.a[0] != 0) {
+      t = S.r[3];
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a1, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[0], modulus))) %
           modulus);
     } else
       t = 0;
-    S.r1 = S.r2;
-    S.r2 = S.r3;
-    S.r3 = S.r4;
-    S.r4 = t;
+    S.r[0] = S.r[1];
+    S.r[1] = S.r[2];
+    S.r[2] = S.r[3];
+    S.r[3] = t;
   }
 
 }  // namespace trng

--- a/inst/include/trng/mrg5.hpp
+++ b/inst/include/trng/mrg5.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,13 +34,15 @@
 
 #define TRNG_MRG5_HPP
 
-#include <ostream>
-#include <istream>
-#include <stdexcept>
 #include <trng/cuda.hpp>
 #include <trng/utility.hpp>
 #include <trng/int_types.hpp>
 #include <trng/int_math.hpp>
+#include <trng/mrg_parameter.hpp>
+#include <trng/mrg_status.hpp>
+#include <ostream>
+#include <istream>
+#include <stdexcept>
 #include <ciso646>
 
 namespace trng {
@@ -50,106 +52,22 @@ namespace trng {
   class mrg5 {
   public:
     // Uniform random number generator concept
-    typedef int32_t result_type;
+    using result_type = int32_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type modulus = 2147483647;
-    static const result_type min_ = 0;
-    static const result_type max_ = modulus - 1;
+    static constexpr result_type modulus = 2147483647;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = modulus - 1;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
-    class parameter_type {
-      result_type a1, a2, a3, a4, a5;
-
-    public:
-      parameter_type() : a1(0), a2(0), a3(0), a4(0), a5(0){};
-      parameter_type(result_type a1, result_type a2, result_type a3, result_type a4,
-                     result_type a5)
-          : a1(a1), a2(a2), a3(a3), a4(a4), a5(a5){};
-
-      friend class mrg5;
-
-      // Equality comparable concept
-      friend bool operator==(const parameter_type &, const parameter_type &);
-      friend bool operator!=(const parameter_type &, const parameter_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const parameter_type &P) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << P.a1 << ' ' << P.a2 << ' ' << P.a3 << ' ' << P.a4 << ' ' << P.a5 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, parameter_type &P) {
-        parameter_type P_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> P_new.a1 >> utility::delim(' ') >> P_new.a2 >>
-            utility::delim(' ') >> P_new.a3 >> utility::delim(' ') >> P_new.a4 >>
-            utility::delim(' ') >> P_new.a5 >> utility::delim(')');
-        if (in)
-          P = P_new;
-        in.flags(flags);
-        return in;
-      }
-    };
-
-    class status_type {
-      result_type r1, r2, r3, r4, r5;
-
-    public:
-      status_type() : r1(0), r2(1), r3(1), r4(1), r5(1){};
-      status_type(result_type r1, result_type r2, result_type r3, result_type r4,
-                  result_type r5)
-          : r1(r1), r2(r2), r3(r3), r4(r4), r5(r5){};
-
-      friend class mrg5;
-
-      // Equality comparable concept
-      friend bool operator==(const status_type &, const status_type &);
-      friend bool operator!=(const status_type &, const status_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const status_type &S) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << S.r1 << ' ' << S.r2 << ' ' << S.r3 << ' ' << S.r4 << ' ' << S.r5 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, status_type &S) {
-        status_type S_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> S_new.r1 >> utility::delim(' ') >> S_new.r2 >>
-            utility::delim(' ') >> S_new.r3 >> utility::delim(' ') >> S_new.r4 >>
-            utility::delim(' ') >> S_new.r5 >> utility::delim(')');
-        if (in)
-          S = S_new;
-        in.flags(flags);
-        return in;
-      }
-    };
+    using parameter_type = mrg_parameter<result_type, 5, mrg5>;
+    using status_type = mrg_status<result_type, 5, mrg5>;
 
     static const parameter_type LEcuyer1;
 
@@ -157,7 +75,7 @@ namespace trng {
     explicit mrg5(const parameter_type &P = LEcuyer1);
     explicit mrg5(unsigned long, const parameter_type &P = LEcuyer1);
     template<typename gen>
-    explicit mrg5(gen &g, const parameter_type &P = LEcuyer1) : P(P), S() {
+    explicit mrg5(gen &g, const parameter_type &P = LEcuyer1) : P{P} {
       seed(g);
     }
 
@@ -165,16 +83,16 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      result_type r1 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r2 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r3 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r4 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r5 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      S.r1 = r1;
-      S.r2 = r2;
-      S.r3 = r3;
-      S.r4 = r4;
-      S.r5 = r5;
+      const result_type r1{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r2{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r3{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r4{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r5{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      S.r[0] = r1;
+      S.r[1] = r2;
+      S.r[2] = r3;
+      S.r[3] = r4;
+      S.r[4] = r5;
     }
     void seed(result_type, result_type, result_type, result_type, result_type);
 
@@ -241,24 +159,24 @@ namespace trng {
 
   TRNG_CUDA_ENABLE
   inline void mrg5::step() {
-    uint64_t t(static_cast<uint64_t>(P.a1) * static_cast<uint64_t>(S.r1) +
-               static_cast<uint64_t>(P.a2) * static_cast<uint64_t>(S.r2) +
-               static_cast<uint64_t>(P.a3) * static_cast<uint64_t>(S.r3) +
-               static_cast<uint64_t>(P.a4) * static_cast<uint64_t>(S.r4));
+    uint64_t t{static_cast<uint64_t>(P.a[0]) * static_cast<uint64_t>(S.r[0]) +
+               static_cast<uint64_t>(P.a[1]) * static_cast<uint64_t>(S.r[1]) +
+               static_cast<uint64_t>(P.a[2]) * static_cast<uint64_t>(S.r[2]) +
+               static_cast<uint64_t>(P.a[3]) * static_cast<uint64_t>(S.r[3])};
     if (t >= static_cast<uint64_t>(2u) * modulus * modulus)
       t -= static_cast<uint64_t>(2u) * modulus * modulus;
-    t += static_cast<uint64_t>(P.a5) * static_cast<uint64_t>(S.r5);
-    S.r5 = S.r4;
-    S.r4 = S.r3;
-    S.r3 = S.r2;
-    S.r2 = S.r1;
-    S.r1 = int_math::modulo<modulus, 5>(t);
+    t += static_cast<uint64_t>(P.a[4]) * static_cast<uint64_t>(S.r[4]);
+    S.r[4] = S.r[3];
+    S.r[3] = S.r[2];
+    S.r[2] = S.r[1];
+    S.r[1] = S.r[0];
+    S.r[0] = int_math::modulo<modulus, 5>(t);
   }
 
   TRNG_CUDA_ENABLE
   inline mrg5::result_type mrg5::operator()() {
     step();
-    return S.r1;
+    return S.r[0];
   }
 
   TRNG_CUDA_ENABLE
@@ -275,25 +193,25 @@ namespace trng {
 #endif
     if (s > 1) {
       jump(n + 1);
-      int32_t q0 = S.r1;
+      const int32_t q0{S.r[0]};
       jump(s);
-      int32_t q1 = S.r1;
+      const int32_t q1{S.r[0]};
       jump(s);
-      int32_t q2 = S.r1;
+      const int32_t q2{S.r[0]};
       jump(s);
-      int32_t q3 = S.r1;
+      const int32_t q3{S.r[0]};
       jump(s);
-      int32_t q4 = S.r1;
+      const int32_t q4{S.r[0]};
       jump(s);
-      int32_t q5 = S.r1;
+      const int32_t q5{S.r[0]};
       jump(s);
-      int32_t q6 = S.r1;
+      const int32_t q6{S.r[0]};
       jump(s);
-      int32_t q7 = S.r1;
+      const int32_t q7{S.r[0]};
       jump(s);
-      int32_t q8 = S.r1;
+      const int32_t q8{S.r[0]};
       jump(s);
-      int32_t q9 = S.r1;
+      const int32_t q9{S.r[0]};
       int32_t a[5], b[25];
       a[0] = q5;
       b[0] = q4;
@@ -326,30 +244,29 @@ namespace trng {
       b[23] = q5;
       b[24] = q4;
       int_math::gauss<5>(b, a, modulus);
-      P.a1 = a[0];
-      P.a2 = a[1];
-      P.a3 = a[2];
-      P.a4 = a[3];
-      P.a5 = a[4];
-      S.r1 = q4;
-      S.r2 = q3;
-      S.r3 = q2;
-      S.r4 = q1;
-      S.r5 = q0;
-      for (int i = 0; i < 5; ++i)
+      P.a[0] = a[0];
+      P.a[1] = a[1];
+      P.a[2] = a[2];
+      P.a[3] = a[3];
+      P.a[4] = a[4];
+      S.r[0] = q4;
+      S.r[1] = q3;
+      S.r[2] = q2;
+      S.r[3] = q1;
+      S.r[4] = q0;
+      for (int i{0}; i < 5; ++i)
         backward();
     }
   }
 
   TRNG_CUDA_ENABLE
   inline void mrg5::jump2(unsigned int s) {
-    int32_t b[25], c[25], d[5], r[5];
-    int32_t t1(P.a1), t2(P.a2), t3(P.a3), t4(P.a4), t5(P.a5);
-    b[0] = P.a1;
-    b[1] = P.a2;
-    b[2] = P.a3;
-    b[3] = P.a4;
-    b[4] = P.a5;
+    result_type b[25], c[25]{};
+    b[0] = P.a[0];
+    b[1] = P.a[1];
+    b[2] = P.a[2];
+    b[3] = P.a[3];
+    b[4] = P.a[4];
     b[5] = 1;
     b[6] = 0;
     b[7] = 0;
@@ -370,131 +287,125 @@ namespace trng {
     b[22] = 0;
     b[23] = 1;
     b[24] = 0;
-    for (unsigned int i(0); i < s; ++i)
-      if ((i & 1) == 0)
-        int_math::matrix_mult<5>(b, b, c, modulus);
-      else
-        int_math::matrix_mult<5>(c, c, b, modulus);
-    r[0] = S.r1;
-    r[1] = S.r2;
-    r[2] = S.r3;
-    r[3] = S.r4;
-    r[4] = S.r5;
-    if ((s & 1) == 0)
+    for (unsigned int i{0}; i < s; ++i) {
+      int_math::matrix_mult<5>(b, b, c, modulus);
+      ++i;
+      if (not(i < s))
+        break;
+      int_math::matrix_mult<5>(c, c, b, modulus);
+    }
+    const result_type r[5]{S.r[0], S.r[1], S.r[2], S.r[3], S.r[4]};
+    result_type d[5];
+    if ((s & 1u) == 0)
       int_math::matrix_vec_mult<5>(b, r, d, modulus);
     else
       int_math::matrix_vec_mult<5>(c, r, d, modulus);
-    S.r1 = d[0];
-    S.r2 = d[1];
-    S.r3 = d[2];
-    S.r4 = d[3];
-    S.r5 = d[4];
-    P.a1 = t1;
-    P.a2 = t2;
-    P.a3 = t3;
-    P.a4 = t4;
-    P.a5 = t5;
+    S.r[0] = d[0];
+    S.r[1] = d[1];
+    S.r[2] = d[2];
+    S.r[3] = d[3];
+    S.r[4] = d[4];
   }
 
   TRNG_CUDA_ENABLE
   inline void mrg5::jump(unsigned long long s) {
     if (s < 16) {
-      for (unsigned int i(0); i < s; ++i)
+      for (unsigned int i{0}; i < s; ++i)
         step();
     } else {
-      unsigned int i(0);
+      unsigned int i{0};
       while (s > 0) {
         if (s % 2 == 1)
           jump2(i);
         ++i;
-        s >>= 1;
+        s >>= 1u;
       }
     }
   }
 
   TRNG_CUDA_ENABLE
-  inline void mrg5::discard(unsigned long long n) { return jump(n); }
+  inline void mrg5::discard(unsigned long long n) { jump(n); }
 
   TRNG_CUDA_ENABLE
   inline void mrg5::backward() {
     result_type t;
-    if (P.a5 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    if (P.a[4] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a3) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[2]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a4) * static_cast<int64_t>(S.r5)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[3]) * static_cast<int64_t>(S.r[4])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a5, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[4], modulus))) %
           modulus);
-    } else if (P.a4 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    } else if (P.a[3] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a3) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[2]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a4, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[3], modulus))) %
           modulus);
-    } else if (P.a3 != 0) {
-      t = S.r2;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+    } else if (P.a[2] != 0) {
+      t = S.r[1];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a3, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[2], modulus))) %
           modulus);
-    } else if (P.a2 != 0) {
-      t = S.r3;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+    } else if (P.a[1] != 0) {
+      t = S.r[2];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a2, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[1], modulus))) %
           modulus);
-    } else if (P.a1 != 0) {
-      t = S.r4;
+    } else if (P.a[0] != 0) {
+      t = S.r[3];
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a1, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[0], modulus))) %
           modulus);
     } else
       t = 0;
-    S.r1 = S.r2;
-    S.r2 = S.r3;
-    S.r3 = S.r4;
-    S.r4 = S.r5;
-    S.r5 = t;
+    S.r[0] = S.r[1];
+    S.r[1] = S.r[2];
+    S.r[2] = S.r[3];
+    S.r[3] = S.r[4];
+    S.r[4] = t;
   }
 
 }  // namespace trng

--- a/inst/include/trng/mrg5s.hpp
+++ b/inst/include/trng/mrg5s.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,13 +34,15 @@
 
 #define TRNG_MRG5S_HPP
 
-#include <ostream>
-#include <istream>
-#include <stdexcept>
 #include <trng/cuda.hpp>
 #include <trng/utility.hpp>
 #include <trng/int_types.hpp>
 #include <trng/int_math.hpp>
+#include <trng/mrg_parameter.hpp>
+#include <trng/mrg_status.hpp>
+#include <ostream>
+#include <istream>
+#include <stdexcept>
 #include <ciso646>
 
 namespace trng {
@@ -50,106 +52,22 @@ namespace trng {
   class mrg5s {
   public:
     // Uniform random number generator concept
-    typedef int32_t result_type;
+    using result_type = int32_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type modulus = 2147461007;  // 2^31 - 22641
-    static const result_type min_ = 0;
-    static const result_type max_ = modulus - 1;
+    static constexpr result_type modulus = 2147461007;  // 2^31 - 22641
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = modulus - 1;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
-    class parameter_type {
-      result_type a1, a2, a3, a4, a5;
-
-    public:
-      parameter_type() : a1(0), a2(0), a3(0), a4(0), a5(0){};
-      parameter_type(result_type a1, result_type a2, result_type a3, result_type a4,
-                     result_type a5)
-          : a1(a1), a2(a2), a3(a3), a4(a4), a5(a5){};
-
-      friend class mrg5s;
-
-      // Equality comparable concept
-      friend bool operator==(const parameter_type &, const parameter_type &);
-      friend bool operator!=(const parameter_type &, const parameter_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const parameter_type &P) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << P.a1 << ' ' << P.a2 << ' ' << P.a3 << ' ' << P.a4 << ' ' << P.a5 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, parameter_type &P) {
-        parameter_type P_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> P_new.a1 >> utility::delim(' ') >> P_new.a2 >>
-            utility::delim(' ') >> P_new.a3 >> utility::delim(' ') >> P_new.a4 >>
-            utility::delim(' ') >> P_new.a5 >> utility::delim(')');
-        if (in)
-          P = P_new;
-        in.flags(flags);
-        return in;
-      }
-    };
-
-    class status_type {
-      result_type r1, r2, r3, r4, r5;
-
-    public:
-      status_type() : r1(0), r2(1), r3(1), r4(1), r5(1){};
-      status_type(result_type r1, result_type r2, result_type r3, result_type r4,
-                  result_type r5)
-          : r1(r1), r2(r2), r3(r3), r4(r4), r5(r5){};
-
-      friend class mrg5s;
-
-      // Equality comparable concept
-      friend bool operator==(const status_type &, const status_type &);
-      friend bool operator!=(const status_type &, const status_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const status_type &S) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << S.r1 << ' ' << S.r2 << ' ' << S.r3 << ' ' << S.r4 << ' ' << S.r5 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, status_type &S) {
-        status_type S_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> S_new.r1 >> utility::delim(' ') >> S_new.r2 >>
-            utility::delim(' ') >> S_new.r3 >> utility::delim(' ') >> S_new.r4 >>
-            utility::delim(' ') >> S_new.r5 >> utility::delim(')');
-        if (in)
-          S = S_new;
-        in.flags(flags);
-        return in;
-      }
-    };
+    using parameter_type = mrg_parameter<result_type, 5, mrg5s>;
+    using status_type = mrg_status<result_type, 5, mrg5s>;
 
     static const parameter_type trng0;
     static const parameter_type trng1;
@@ -158,7 +76,7 @@ namespace trng {
     explicit mrg5s(const parameter_type &P = trng0);
     explicit mrg5s(unsigned long, const parameter_type &P = trng0);
     template<typename gen>
-    explicit mrg5s(gen &g, const parameter_type &P = trng0) : P(P), S() {
+    explicit mrg5s(gen &g, const parameter_type &P = trng0) : P{P} {
       seed(g);
     }
 
@@ -166,16 +84,16 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      result_type r1 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r2 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r3 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r4 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r5 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      S.r1 = r1;
-      S.r2 = r2;
-      S.r3 = r3;
-      S.r4 = r4;
-      S.r5 = r5;
+      const result_type r1{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r2{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r3{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r4{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r5{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      S.r[0] = r1;
+      S.r[1] = r2;
+      S.r[2] = r3;
+      S.r[3] = r4;
+      S.r[4] = r5;
     }
     void seed(result_type, result_type, result_type, result_type, result_type);
 
@@ -219,6 +137,8 @@ namespace trng {
     void jump2(unsigned int);
     TRNG_CUDA_ENABLE
     void jump(unsigned long long);
+    TRNG_CUDA_ENABLE
+    void discard(unsigned long long);
 
     // Other useful methods
     static const char *name();
@@ -240,24 +160,24 @@ namespace trng {
 
   TRNG_CUDA_ENABLE
   inline void mrg5s::step() {
-    uint64_t t(static_cast<uint64_t>(P.a1) * static_cast<uint64_t>(S.r1) +
-               static_cast<uint64_t>(P.a2) * static_cast<uint64_t>(S.r2) +
-               static_cast<uint64_t>(P.a3) * static_cast<uint64_t>(S.r3) +
-               static_cast<uint64_t>(P.a4) * static_cast<uint64_t>(S.r4));
+    uint64_t t{static_cast<uint64_t>(P.a[0]) * static_cast<uint64_t>(S.r[0]) +
+               static_cast<uint64_t>(P.a[1]) * static_cast<uint64_t>(S.r[1]) +
+               static_cast<uint64_t>(P.a[2]) * static_cast<uint64_t>(S.r[2]) +
+               static_cast<uint64_t>(P.a[3]) * static_cast<uint64_t>(S.r[3])};
     if (t >= static_cast<uint64_t>(2u) * modulus * modulus)
       t -= static_cast<uint64_t>(2u) * modulus * modulus;
-    t += static_cast<uint64_t>(P.a5) * static_cast<uint64_t>(S.r5);
-    S.r5 = S.r4;
-    S.r4 = S.r3;
-    S.r3 = S.r2;
-    S.r2 = S.r1;
-    S.r1 = int_math::modulo<modulus, 5>(t);
+    t += static_cast<uint64_t>(P.a[4]) * static_cast<uint64_t>(S.r[4]);
+    S.r[4] = S.r[3];
+    S.r[3] = S.r[2];
+    S.r[2] = S.r[1];
+    S.r[1] = S.r[0];
+    S.r[0] = int_math::modulo<modulus, 5>(t);
   }
 
   TRNG_CUDA_ENABLE
   inline mrg5s::result_type mrg5s::operator()() {
     step();
-    return S.r1;
+    return S.r[0];
   }
 
   TRNG_CUDA_ENABLE
@@ -274,25 +194,25 @@ namespace trng {
 #endif
     if (s > 1) {
       jump(n + 1);
-      int32_t q0 = S.r1;
+      const int32_t q0{S.r[0]};
       jump(s);
-      int32_t q1 = S.r1;
+      const int32_t q1{S.r[0]};
       jump(s);
-      int32_t q2 = S.r1;
+      const int32_t q2{S.r[0]};
       jump(s);
-      int32_t q3 = S.r1;
+      const int32_t q3{S.r[0]};
       jump(s);
-      int32_t q4 = S.r1;
+      const int32_t q4{S.r[0]};
       jump(s);
-      int32_t q5 = S.r1;
+      const int32_t q5{S.r[0]};
       jump(s);
-      int32_t q6 = S.r1;
+      const int32_t q6{S.r[0]};
       jump(s);
-      int32_t q7 = S.r1;
+      const int32_t q7{S.r[0]};
       jump(s);
-      int32_t q8 = S.r1;
+      const int32_t q8{S.r[0]};
       jump(s);
-      int32_t q9 = S.r1;
+      const int32_t q9{S.r[0]};
       int32_t a[5], b[25];
       a[0] = q5;
       b[0] = q4;
@@ -325,30 +245,29 @@ namespace trng {
       b[23] = q5;
       b[24] = q4;
       int_math::gauss<5>(b, a, modulus);
-      P.a1 = a[0];
-      P.a2 = a[1];
-      P.a3 = a[2];
-      P.a4 = a[3];
-      P.a5 = a[4];
-      S.r1 = q4;
-      S.r2 = q3;
-      S.r3 = q2;
-      S.r4 = q1;
-      S.r5 = q0;
-      for (int i = 0; i < 5; ++i)
+      P.a[0] = a[0];
+      P.a[1] = a[1];
+      P.a[2] = a[2];
+      P.a[3] = a[3];
+      P.a[4] = a[4];
+      S.r[0] = q4;
+      S.r[1] = q3;
+      S.r[2] = q2;
+      S.r[3] = q1;
+      S.r[4] = q0;
+      for (int i{0}; i < 5; ++i)
         backward();
     }
   }
 
   TRNG_CUDA_ENABLE
   inline void mrg5s::jump2(unsigned int s) {
-    int32_t b[25], c[25], d[5], r[5];
-    int32_t t1(P.a1), t2(P.a2), t3(P.a3), t4(P.a4), t5(P.a5);
-    b[0] = P.a1;
-    b[1] = P.a2;
-    b[2] = P.a3;
-    b[3] = P.a4;
-    b[4] = P.a5;
+    result_type b[25], c[25];
+    b[0] = P.a[0];
+    b[1] = P.a[1];
+    b[2] = P.a[2];
+    b[3] = P.a[3];
+    b[4] = P.a[4];
     b[5] = 1;
     b[6] = 0;
     b[7] = 0;
@@ -369,128 +288,125 @@ namespace trng {
     b[22] = 0;
     b[23] = 1;
     b[24] = 0;
-    for (unsigned int i(0); i < s; ++i)
-      if ((i & 1) == 0)
-        int_math::matrix_mult<5>(b, b, c, modulus);
-      else
-        int_math::matrix_mult<5>(c, c, b, modulus);
-    r[0] = S.r1;
-    r[1] = S.r2;
-    r[2] = S.r3;
-    r[3] = S.r4;
-    r[4] = S.r5;
-    if ((s & 1) == 0)
+    for (unsigned int i{0}; i < s; ++i) {
+      int_math::matrix_mult<5>(b, b, c, modulus);
+      ++i;
+      if (not(i < s))
+        break;
+      int_math::matrix_mult<5>(c, c, b, modulus);
+    }
+    const result_type r[5]{S.r[0], S.r[1], S.r[2], S.r[3], S.r[4]};
+    result_type d[5];
+    if ((s & 1u) == 0)
       int_math::matrix_vec_mult<5>(b, r, d, modulus);
     else
       int_math::matrix_vec_mult<5>(c, r, d, modulus);
-    S.r1 = d[0];
-    S.r2 = d[1];
-    S.r3 = d[2];
-    S.r4 = d[3];
-    S.r5 = d[4];
-    P.a1 = t1;
-    P.a2 = t2;
-    P.a3 = t3;
-    P.a4 = t4;
-    P.a5 = t5;
+    S.r[0] = d[0];
+    S.r[1] = d[1];
+    S.r[2] = d[2];
+    S.r[3] = d[3];
+    S.r[4] = d[4];
   }
 
   TRNG_CUDA_ENABLE
   inline void mrg5s::jump(unsigned long long s) {
     if (s < 16) {
-      for (unsigned int i(0); i < s; ++i)
+      for (unsigned int i{0}; i < s; ++i)
         step();
     } else {
-      unsigned int i(0);
+      unsigned int i{0};
       while (s > 0) {
         if (s % 2 == 1)
           jump2(i);
         ++i;
-        s >>= 1;
+        s >>= 1u;
       }
     }
   }
 
   TRNG_CUDA_ENABLE
+  inline void mrg5s::discard(unsigned long long n) { jump(n); }
+
+  TRNG_CUDA_ENABLE
   inline void mrg5s::backward() {
     result_type t;
-    if (P.a5 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    if (P.a[4] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a3) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[2]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a4) * static_cast<int64_t>(S.r5)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[3]) * static_cast<int64_t>(S.r[4])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a5, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[4], modulus))) %
           modulus);
-    } else if (P.a4 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    } else if (P.a[3] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a3) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[2]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a4, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[3], modulus))) %
           modulus);
-    } else if (P.a3 != 0) {
-      t = S.r2;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+    } else if (P.a[2] != 0) {
+      t = S.r[1];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a3, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[2], modulus))) %
           modulus);
-    } else if (P.a2 != 0) {
-      t = S.r3;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+    } else if (P.a[1] != 0) {
+      t = S.r[2];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a2, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[1], modulus))) %
           modulus);
-    } else if (P.a1 != 0) {
-      t = S.r4;
+    } else if (P.a[0] != 0) {
+      t = S.r[3];
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a1, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[0], modulus))) %
           modulus);
     } else
       t = 0;
-    S.r1 = S.r2;
-    S.r2 = S.r3;
-    S.r3 = S.r4;
-    S.r4 = S.r5;
-    S.r5 = t;
+    S.r[0] = S.r[1];
+    S.r[1] = S.r[2];
+    S.r[2] = S.r[3];
+    S.r[3] = S.r[4];
+    S.r[4] = t;
   }
 
 }  // namespace trng

--- a/inst/include/trng/mrg_parameter.hpp
+++ b/inst/include/trng/mrg_parameter.hpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2000-2020, Heiko Bauke
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//   * Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//
+//   * Redistributions in binary form must reproduce the above
+//     copyright notice, this list of conditions and the following
+//     disclaimer in the documentation and/or other materials provided
+//     with the distribution.
+//
+//   * Neither the name of the copyright holder nor the names of its
+//     contributors may be used to endorse or promote products derived
+//     from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+// OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if !(defined TRNG_MRG_PARAMETER_HPP)
+#define TRNG_MRG_PARAMETER_HPP
+
+#include <ostream>
+#include <istream>
+#include <algorithm>
+
+namespace trng {
+
+  template<typename result_type, int n, typename F>
+  class mrg_parameter {
+  protected:
+    result_type a[n]{};
+
+  public:
+    mrg_parameter() = default;
+    explicit mrg_parameter(result_type a1, result_type a2) : a{a1, a2} {
+      static_assert(n == 2, "dimension must be 2");
+    }
+    explicit mrg_parameter(result_type a1, result_type a2, result_type a3) : a{a1, a2, a3} {
+      static_assert(n == 3, "dimension must be 3");
+    }
+    explicit mrg_parameter(result_type a1, result_type a2, result_type a3, result_type a4)
+        : a{a1, a2, a3, a4} {
+      static_assert(n == 4, "dimension must be 4");
+    }
+    explicit mrg_parameter(result_type a1, result_type a2, result_type a3, result_type a4,
+                           result_type a5)
+        : a{a1, a2, a3, a4, a5} {
+      static_assert(n == 5, "dimension must be 5");
+    }
+
+    friend F;
+
+    // Equality comparable concept
+    friend bool operator==(const mrg_parameter &P1, const mrg_parameter &P2) {
+      return std::equal(P1.a, P1.a + n, P2.a);
+    }
+
+    friend bool operator!=(const mrg_parameter &P1, const mrg_parameter &P2) {
+      return not(P1 == P2);
+    }
+
+
+    // Streamable concept
+    template<typename char_t, typename traits_t>
+    friend std::basic_ostream<char_t, traits_t> &operator<<(
+        std::basic_ostream<char_t, traits_t> &out, const mrg_parameter &P) {
+      std::ios_base::fmtflags flags(out.flags());
+      out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
+      out << '(';
+      for (int i{0}; i < n; ++i) {
+        out << P.a[i];
+        if (i + 1 < n)
+          out << ' ';
+      }
+      out << ')';
+      out.flags(flags);
+      return out;
+    }
+
+    template<typename char_t, typename traits_t>
+    friend std::basic_istream<char_t, traits_t> &operator>>(
+        std::basic_istream<char_t, traits_t> &in, mrg_parameter &P) {
+      mrg_parameter P_new;
+      std::ios_base::fmtflags flags(in.flags());
+      in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
+      in >> utility::delim('(');
+      for (int i{0}; i < n; ++i) {
+        in >> P_new.a[i];
+        if (i + 1 < n)
+          in >> utility::delim(' ');
+      }
+      in >> utility::delim(')');
+      if (in)
+        P = P_new;
+      in.flags(flags);
+      return in;
+    }
+  };
+
+}  // namespace trng
+
+#endif

--- a/inst/include/trng/mrg_status.hpp
+++ b/inst/include/trng/mrg_status.hpp
@@ -1,0 +1,118 @@
+// Copyright (c) 2000-2020, Heiko Bauke
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//   * Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//
+//   * Redistributions in binary form must reproduce the above
+//     copyright notice, this list of conditions and the following
+//     disclaimer in the documentation and/or other materials provided
+//     with the distribution.
+//
+//   * Neither the name of the copyright holder nor the names of its
+//     contributors may be used to endorse or promote products derived
+//     from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+// OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if !(defined TRNG_MRG_STATUS_HPP)
+#define TRNG_MRG_STATUS_HPP
+
+#include <ostream>
+#include <istream>
+#include <algorithm>
+
+namespace trng {
+
+  template<typename result_type, int n, typename F>
+  class mrg_status {
+  protected:
+    result_type r[n];
+
+  public:
+    mrg_status() {
+      r[0] = 0;
+      for (int i{1}; i < n; ++i)
+        r[i] = 1;
+    }
+    explicit mrg_status(result_type r1, result_type r2) : r{r1, r2} {
+      static_assert(n == 2, "dimension must be 2");
+    }
+    explicit mrg_status(result_type r1, result_type r2, result_type r3) : r{r1, r2, r3} {
+      static_assert(n == 3, "dimension must be 3");
+    }
+    explicit mrg_status(result_type r1, result_type r2, result_type r3, result_type r4)
+        : r{r1, r2, r3, r4} {
+      static_assert(n == 4, "dimension must be 4");
+    }
+    explicit mrg_status(result_type r1, result_type r2, result_type r3, result_type r4,
+                        result_type r5)
+        : r{r1, r2, r3, r4, r5} {
+      static_assert(n == 5, "dimension must be 5");
+    }
+
+    friend F;
+
+    // Equality comparable concept
+    friend bool operator==(const mrg_status &S1, const mrg_status &S2) {
+      return std::equal(S1.r, S1.r + n, S2.r);
+    }
+
+    friend bool operator!=(const mrg_status &P1, const mrg_status &P2) { return not(P1 == P2); }
+
+
+    // Streamable concept
+    template<typename char_t, typename traits_t>
+    friend std::basic_ostream<char_t, traits_t> &operator<<(
+        std::basic_ostream<char_t, traits_t> &out, const mrg_status &S) {
+      std::ios_base::fmtflags flags(out.flags());
+      out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
+      out << '(';
+      for (int i{0}; i < n; ++i) {
+        out << S.r[i];
+        if (i + 1 < n)
+          out << ' ';
+      }
+      out << ')';
+      out.flags(flags);
+      return out;
+    }
+
+    template<typename char_t, typename traits_t>
+    friend std::basic_istream<char_t, traits_t> &operator>>(
+        std::basic_istream<char_t, traits_t> &in, mrg_status &S) {
+      mrg_status S_new;
+      std::ios_base::fmtflags flags(in.flags());
+      in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
+      in >> utility::delim('(');
+      for (int i{0}; i < n; ++i) {
+        in >> S_new.r[i];
+        if (i + 1 < n)
+          in >> utility::delim(' ');
+      }
+      in >> utility::delim(')');
+      if (in)
+        S = S_new;
+      in.flags(flags);
+      return in;
+    }
+  };
+
+}  // namespace trng
+
+#endif

--- a/inst/include/trng/mt19937.hpp
+++ b/inst/include/trng/mt19937.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -46,43 +46,39 @@
 #define TRNG_MT19937_HPP
 
 #include <trng/limits.hpp>
+#include <trng/int_types.hpp>
+#include <trng/utility.hpp>
+#include <trng/generate_canonical.hpp>
 #include <climits>
 #include <stdexcept>
 #include <ostream>
 #include <istream>
-#include <trng/int_types.hpp>
-#include <trng/utility.hpp>
-#include <trng/generate_canonical.hpp>
 #include <ciso646>
 
 namespace trng {
 
-  class mt19937;
-
   class mt19937 {
   public:
     // Uniform random number generator concept
-    typedef uint32_t result_type;
+    using result_type = uint32_t;
     result_type operator()();
 
   private:
-    static const result_type min_ = 0;
-    static const result_type max_ = 4294967295u;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = 4294967295u;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
   private:
-    static const int N = 624;
-    static const int M = 397;
-    static const result_type UM = 0x80000000u;  // most significant bit
-    static const result_type LM = 0x7FFFFFFFu;  // least significant 31 bits
+    static constexpr int N = 624;
+    static constexpr int M = 397;
+    static constexpr result_type UM = 0x80000000u;  // most significant bit
+    static constexpr result_type LM = 0x7FFFFFFFu;  // least significant 31 bits
+
   public:
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
     class parameter_type {
     public:
       parameter_type() = default;
@@ -119,7 +115,7 @@ namespace trng {
     };
 
     class status_type {
-      static const int N{624};
+      static constexpr int N{624};
       int mti{0};
       result_type mt[N]{};
 
@@ -162,14 +158,14 @@ namespace trng {
     explicit mt19937(unsigned long);
 
     template<typename gen>
-    explicit mt19937(gen &g) : P(), S() {
+    explicit mt19937(gen &g) {
       seed(g);
     }
 
     void seed();
     template<typename gen>
     void seed(gen &g) {
-      result_type r = g();
+      const unsigned long r(g());
       seed(r);
     }
     void seed(unsigned long);
@@ -222,32 +218,31 @@ namespace trng {
   // Inline and template methods
 
   inline mt19937::result_type mt19937::operator()() {
-    result_type x;
-    const result_type mag01[2] = {0u, 0x9908b0dfu};
+    const result_type mag01[2]{0u, 0x9908b0dfu};
     if (S.mti >= N) {  // generate N words at one time
-      int i;
-      for (i = 0; i < N - M; ++i) {
-        x = (S.mt[i] & mt19937::UM) | (S.mt[i + 1] & mt19937::LM);
-        S.mt[i] = S.mt[i + M] ^ (x >> 1) ^ mag01[x & 0x1u];
+      int i{0};
+      for (; i < N - M; ++i) {
+        const result_type x{(S.mt[i] & mt19937::UM) | (S.mt[i + 1] & mt19937::LM)};
+        S.mt[i] = S.mt[i + M] ^ (x >> 1u) ^ mag01[x & 0x1u];
       }
       for (; i < N - 1; ++i) {
-        x = (S.mt[i] & mt19937::UM) | (S.mt[i + 1] & LM);
-        S.mt[i] = S.mt[i + (M - N)] ^ (x >> 1) ^ mag01[x & 0x1u];
+        const result_type x{(S.mt[i] & mt19937::UM) | (S.mt[i + 1] & LM)};
+        S.mt[i] = S.mt[i + (M - N)] ^ (x >> 1u) ^ mag01[x & 0x1u];
       }
-      x = (S.mt[N - 1] & mt19937::UM) | (S.mt[0] & mt19937::LM);
-      S.mt[N - 1] = S.mt[M - 1] ^ (x >> 1) ^ mag01[x & 0x1u];
+      const result_type x{(S.mt[N - 1] & mt19937::UM) | (S.mt[0] & mt19937::LM)};
+      S.mt[N - 1] = S.mt[M - 1] ^ (x >> 1u) ^ mag01[x & 0x1u];
       S.mti = 0;
     }
-    x = S.mt[S.mti++];
-    x ^= (x >> 11);
-    x ^= (x << 7) & 0x9d2c5680u;
-    x ^= (x << 15) & 0xefc60000u;
-    x ^= (x >> 18);
+    result_type x{S.mt[S.mti++]};
+    x ^= (x >> 11u);
+    x ^= (x << 7u) & 0x9d2c5680u;
+    x ^= (x << 15u) & 0xefc60000u;
+    x ^= (x >> 18u);
     return x;
   }
 
   inline void mt19937::discard(unsigned long long n) {
-    for (unsigned long long i(0); i < n; ++i)
+    for (unsigned long long i{0}; i < n; ++i)
       this->operator()();
   }
 

--- a/inst/include/trng/mt19937_64.hpp
+++ b/inst/include/trng/mt19937_64.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -49,46 +49,42 @@
 #define TRNG_MT19937_64_HPP
 
 #include <trng/limits.hpp>
+#include <trng/int_types.hpp>
+#include <trng/utility.hpp>
+#include <trng/generate_canonical.hpp>
 #include <climits>
 #include <stdexcept>
 #include <ostream>
 #include <istream>
-#include <trng/int_types.hpp>
-#include <trng/utility.hpp>
-#include <trng/generate_canonical.hpp>
 #include <ciso646>
 
 namespace trng {
 
-  class mt19937_64;
-
   class mt19937_64 {
   public:
     // Uniform random number generator concept
-    typedef uint64_t result_type;
+    using result_type = uint64_t;
     result_type operator()();
 
   private:
-    static const result_type min_ = 0;
-    static const result_type max_ = 18446744073709551615u;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = 18446744073709551615u;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
   private:
-    static const int N = 312;
-    static const int M = 156;
-    static const result_type UM = 0xFFFFFFFF80000000u;  // most significant 33 bits
-    static const result_type LM = 0x7FFFFFFFu;          // least significant 31 bits
+    static constexpr int N = 312;
+    static constexpr int M = 156;
+    static constexpr result_type UM = 0xFFFFFFFF80000000u;  // most significant 33 bits
+    static constexpr result_type LM = 0x7FFFFFFFu;          // least significant 31 bits
+
   public:
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
     class parameter_type {
     public:
-      parameter_type(){};
+      parameter_type() = default;
 
       friend class mt19937_64;
 
@@ -122,15 +118,12 @@ namespace trng {
     };
 
     class status_type {
-      static const int N = 312;
-      int mti;
-      result_type mt[N];
+      static constexpr int N = 312;
+      int mti{0};
+      result_type mt[N]{};
 
     public:
-      status_type() : mti(0) {
-        for (int i = 0; i < N; ++i)
-          mt[i] = 0;
-      }
+      status_type() = default;
 
       friend class mt19937_64;
 
@@ -169,7 +162,7 @@ namespace trng {
     explicit mt19937_64(unsigned long);
 
     template<typename gen>
-    explicit mt19937_64(gen &g) : P(), S() {
+    explicit mt19937_64(gen &g) {
       seed(g);
     }
 
@@ -177,9 +170,9 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      result_type r = 0;
-      for (int i = 0; i < 2; ++i) {
-        r <<= 32;
+      result_type r{0};
+      for (int i{0}; i < 2; ++i) {
+        r <<= 32u;
         r += g();
       }
       seed(r);
@@ -233,33 +226,31 @@ namespace trng {
   // Inline and template methods
 
   inline mt19937_64::result_type mt19937_64::operator()() {
-    result_type x;
-    const result_type mag01[2] = {0u, 0xB5026F5AA96619E9u};
-
+    const result_type mag01[2]{0u, 0xB5026F5AA96619E9u};
     if (S.mti >= mt19937_64::N) {  // generate N words at one time
-      int i;
-      for (i = 0; i < mt19937_64::N - mt19937_64::M; ++i) {
-        x = (S.mt[i] & mt19937_64::UM) | (S.mt[i + 1] & mt19937_64::LM);
-        S.mt[i] = S.mt[i + mt19937_64::M] ^ (x >> 1) ^ mag01[(int)(x & 1u)];
+      int i{0};
+      for (; i < mt19937_64::N - mt19937_64::M; ++i) {
+        const result_type x{(S.mt[i] & mt19937_64::UM) | (S.mt[i + 1] & mt19937_64::LM)};
+        S.mt[i] = S.mt[i + mt19937_64::M] ^ (x >> 1u) ^ mag01[(int)(x & 1u)];
       }
       for (; i < mt19937_64::N - 1; ++i) {
-        x = (S.mt[i] & mt19937_64::UM) | (S.mt[i + 1] & mt19937_64::LM);
-        S.mt[i] = S.mt[i + (mt19937_64::M - mt19937_64::N)] ^ (x >> 1) ^ mag01[(int)(x & 1u)];
+        const result_type x{(S.mt[i] & mt19937_64::UM) | (S.mt[i + 1] & mt19937_64::LM)};
+        S.mt[i] = S.mt[i + (mt19937_64::M - mt19937_64::N)] ^ (x >> 1u) ^ mag01[(int)(x & 1u)];
       }
-      x = (S.mt[mt19937_64::N - 1] & UM) | (S.mt[0] & LM);
-      S.mt[N - 1] = S.mt[mt19937_64::M - 1] ^ (x >> 1) ^ mag01[(int)(x & 1u)];
+      const result_type x{(S.mt[mt19937_64::N - 1] & UM) | (S.mt[0] & LM)};
+      S.mt[N - 1] = S.mt[mt19937_64::M - 1] ^ (x >> 1u) ^ mag01[(int)(x & 1u)];
       S.mti = 0;
     }
-    x = S.mt[S.mti++];
-    x ^= (x >> 29) & 0x5555555555555555u;
-    x ^= (x << 17) & 0x71D67FFFEDA60000u;
-    x ^= (x << 37) & 0xFFF7EEE000000000u;
-    x ^= (x >> 43);
+    result_type x{S.mt[S.mti++]};
+    x ^= (x >> 29u) & 0x5555555555555555u;
+    x ^= (x << 17u) & 0x71D67FFFEDA60000u;
+    x ^= (x << 37u) & 0xFFF7EEE000000000u;
+    x ^= (x >> 43u);
     return x;
   }
 
   inline void mt19937_64::discard(unsigned long long n) {
-    for (unsigned long long i(0); i < n; ++i)
+    for (unsigned long long i{0}; i < n; ++i)
       this->operator()();
   }
 

--- a/inst/include/trng/negative_binomial_dist.hpp
+++ b/inst/include/trng/negative_binomial_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -38,29 +38,30 @@
 #include <trng/utility.hpp>
 #include <trng/math.hpp>
 #include <trng/special_functions.hpp>
+#include <cstddef>
 #include <ostream>
 #include <istream>
 #include <iomanip>
 #include <vector>
+#include <ciso646>
 
 namespace trng {
 
   // non-uniform random number generator class
   class negative_binomial_dist {
   public:
-    typedef int result_type;
-    class param_type;
+    using result_type = int;
 
     class param_type {
     private:
-      double p_;
-      double r_;
+      double p_{0};
+      double r_{0};
       std::vector<double> P_;
 
       void calc_probabilities() {
         P_ = std::vector<double>();
-        int x = 0;
-        double p = 0.0;
+        int x{0};
+        double p{0.0};
         while (p < 1.0 - 1.0 / 4096.0) {
           p += math::exp(math::ln_Gamma(r_ + x) - math::ln_Gamma(static_cast<double>(x + 1)) -
                          math::ln_Gamma(r_)) *
@@ -82,8 +83,8 @@ namespace trng {
         r_ = r_new;
         calc_probabilities();
       }
-      param_type() : p_(0), r_(0) {}
-      param_type(double p, double r) : p_(p), r_(r) { calc_probabilities(); }
+      param_type() = default;
+      explicit param_type(double p, double r) : p_{p}, r_{r} { calc_probabilities(); }
       friend class negative_binomial_dist;
     };
 
@@ -92,15 +93,15 @@ namespace trng {
 
   public:
     // constructor
-    explicit negative_binomial_dist(double p, double r) : P(p, r) {}
-    explicit negative_binomial_dist(const param_type &P) : P(P) {}
+    explicit negative_binomial_dist(double p, double r) : P{p, r} {}
+    explicit negative_binomial_dist(const param_type &P) : P{P} {}
     // reset internal state
     void reset() {}
     // random numbers
     template<typename R>
     int operator()(R &r) {
-      double p(utility::uniformco<double>(r));
-      int x(utility::discrete(p, P.P_.begin(), P.P_.end()));
+      double p{utility::uniformco<double>(r)};
+      std::size_t x{utility::discrete(p, P.P_.begin(), P.P_.end())};
       if (x + 1 == P.P_.size()) {
         p -= cdf(x);
         while (p > 0) {
@@ -108,7 +109,7 @@ namespace trng {
           p -= pdf(x);
         }
       }
-      return x;
+      return static_cast<int>(x);
     }
     template<typename R>
     int operator()(R &r, const param_type &p) {
@@ -134,7 +135,7 @@ namespace trng {
     }
     // cumulative density function
     double cdf(int x) const {
-      double res = 0;
+      double res{0};
       while (x >= 0) {
         res += pdf(x);
         --x;
@@ -146,13 +147,13 @@ namespace trng {
   // -------------------------------------------------------------------
 
   // EqualityComparable concept
-  inline bool operator==(const negative_binomial_dist::param_type &p1,
-                         const negative_binomial_dist::param_type &p2) {
-    return p1.p() == p2.p() and p1.r() == p2.r();
+  bool operator==(const negative_binomial_dist::param_type &P1,
+                  const negative_binomial_dist::param_type &P2) {
+    return P1.p() == P2.p() and P1.r() == P2.r();
   }
-  inline bool operator!=(const negative_binomial_dist::param_type &p1,
-                         const negative_binomial_dist::param_type &p2) {
-    return !(p1 == p2);
+  bool operator!=(const negative_binomial_dist::param_type &P1,
+                  const negative_binomial_dist::param_type &P2) {
+    return !(P1 == P2);
   }
 
   // Streamable concept
@@ -183,10 +184,10 @@ namespace trng {
   // -------------------------------------------------------------------
 
   // EqualityComparable concept
-  inline bool operator==(const negative_binomial_dist &g1, const negative_binomial_dist &g2) {
+  bool operator==(const negative_binomial_dist &g1, const negative_binomial_dist &g2) {
     return g1.param() == g2.param();
   }
-  inline bool operator!=(const negative_binomial_dist &g1, const negative_binomial_dist &g2) {
+  bool operator!=(const negative_binomial_dist &g1, const negative_binomial_dist &g2) {
     return g1.param() != g2.param();
   }
 
@@ -204,13 +205,13 @@ namespace trng {
   template<typename char_t, typename traits_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    negative_binomial_dist &g) {
-    negative_binomial_dist::param_type p;
+    negative_binomial_dist::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[negative_binomial ") >> p >>
+    in >> utility::ignore_spaces() >> utility::delim("[negative_binomial ") >> P >>
         utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/normal_dist.hpp
+++ b/inst/include/trng/normal_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -51,12 +51,11 @@ namespace trng {
   template<typename float_t = double>
   class normal_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type mu_, sigma_;
+      result_type mu_{0}, sigma_{1};
 
     public:
       TRNG_CUDA_ENABLE
@@ -68,47 +67,47 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void sigma(result_type sigma_new) { sigma_ = sigma_new; }
       TRNG_CUDA_ENABLE
-      param_type() : mu_(0), sigma_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(result_type mu, result_type sigma) : mu_(mu), sigma_(sigma) {}
+      explicit param_type(result_type mu, result_type sigma) : mu_{mu}, sigma_{sigma} {}
 
       friend class normal_dist;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << p.mu()
-            << ' ' << p.sigma() << ')';
+        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << P.mu()
+            << ' ' << P.sigma() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t mu, sigma;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> mu >> utility::delim(' ') >> sigma >> utility::delim(')');
         if (in)
-          p = param_type(mu, sigma);
+          P = param_type(mu, sigma);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    normal_dist(result_type mu, result_type sigma) : p(mu, sigma) {}
+    explicit normal_dist(result_type mu, result_type sigma) : P{mu, sigma} {}
     TRNG_CUDA_ENABLE
-    explicit normal_dist(const param_type &p) : p(p) {}
+    explicit normal_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -118,8 +117,8 @@ namespace trng {
       return icdf(utility::uniformoo<result_type>(r));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      normal_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      normal_dist g(P);
       return g(r);
     }
     // property methods
@@ -128,34 +127,34 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &P_new) { P = P_new; }
     TRNG_CUDA_ENABLE
-    result_type mu() const { return p.mu(); }
+    result_type mu() const { return P.mu(); }
     TRNG_CUDA_ENABLE
-    void mu(result_type mu_new) { p.mu(mu_new); }
+    void mu(result_type mu_new) { P.mu(mu_new); }
     TRNG_CUDA_ENABLE
-    result_type sigma() const { return p.sigma(); }
+    result_type sigma() const { return P.sigma(); }
     TRNG_CUDA_ENABLE
-    void sigma(result_type sigma_new) { p.sigma(sigma_new); }
+    void sigma(result_type sigma_new) { P.sigma(sigma_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
-      result_type t(x - p.mu());
-      return math::constants<result_type>::one_over_sqrt_2pi() / p.sigma() *
-             math::exp(t * t / (-2 * p.sigma() * p.sigma()));
+      const result_type t{x - P.mu()};
+      return math::constants<result_type>::one_over_sqrt_2pi / P.sigma() *
+             math::exp(t * t / (-2 * P.sigma() * P.sigma()));
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
-      x -= p.mu();
-      x /= p.sigma();
+      x -= P.mu();
+      x /= P.sigma();
       return math::Phi(x);
     }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
-    result_type icdf(result_type x) const { return math::inv_Phi(x) * p.sigma() + p.mu(); }
+    result_type icdf(result_type x) const { return math::inv_Phi(x) * P.sigma() + P.mu(); }
   };
 
   // -------------------------------------------------------------------

--- a/inst/include/trng/pareto_dist.hpp
+++ b/inst/include/trng/pareto_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -50,12 +50,11 @@ namespace trng {
   template<typename float_t = double>
   class pareto_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type gamma_, theta_;
+      result_type gamma_{1}, theta_{1};
 
     public:
       TRNG_CUDA_ENABLE
@@ -67,55 +66,56 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void theta(result_type theta_new) { theta_ = theta_new; }
       TRNG_CUDA_ENABLE
-      param_type() : gamma_(1), theta_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(result_type gamma, result_type theta) : gamma_(gamma), theta_(theta) {}
+      explicit param_type(result_type gamma, result_type theta)
+          : gamma_{gamma}, theta_{theta} {}
 
       friend class pareto_dist;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1)
-            << p.gamma() << ' ' << p.theta() << ')';
+            << P.gamma() << ' ' << P.theta() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t gamma, theta;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> gamma >> utility::delim(' ') >> theta >>
             utility::delim(')');
         if (in)
-          p = param_type(gamma, theta);
+          P = param_type(gamma, theta);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    pareto_dist(result_type gamma, result_type theta) : p(gamma, theta) {}
+    explicit pareto_dist(result_type gamma, result_type theta) : P{gamma, theta} {}
     TRNG_CUDA_ENABLE
-    explicit pareto_dist(const param_type &p) : p(p) {}
+    explicit pareto_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
     // random numbers
     template<typename R>
     TRNG_CUDA_ENABLE result_type operator()(R &r) {
-      return (math::pow(utility::uniformoo<result_type>(r), -1 / p.gamma()) - 1) * p.theta();
+      return (math::pow(utility::uniformoo<result_type>(r), -1 / P.gamma()) - 1) * P.theta();
     }
     template<typename R>
     TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
@@ -128,31 +128,29 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &P_new) { P = P_new; }
     TRNG_CUDA_ENABLE
-    result_type gamma() const { return p.gamma(); }
+    result_type gamma() const { return P.gamma(); }
     TRNG_CUDA_ENABLE
-    void gamma(result_type gamma_new) { p.gamma(gamma_new); }
+    void gamma(result_type gamma_new) { P.gamma(gamma_new); }
     TRNG_CUDA_ENABLE
-    result_type theta() const { return p.theta(); }
+    result_type theta() const { return P.theta(); }
     TRNG_CUDA_ENABLE
-    void theta(result_type theta_new) { p.theta(theta_new); }
+    void theta(result_type theta_new) { P.theta(theta_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
       if (x < 0)
         return 0;
-      else
-        return p.gamma() / p.theta() * math::pow(1 + x / p.theta(), -p.gamma() - 1);
+      return P.gamma() / P.theta() * math::pow(1 + x / P.theta(), -P.gamma() - 1);
     }
     // cumulative density function
     result_type cdf(result_type x) const {
       if (x <= 0)
         return 0;
-      else
-        return 1 - math::pow(1 + x / p.theta(), -p.gamma());
+      return 1 - math::pow(1 + x / P.theta(), -P.gamma());
     }
     // inverse cumulative density function
     result_type icdf(result_type x) const {
@@ -166,7 +164,7 @@ namespace trng {
         return 0;
       if (x == 1)
         return math::numeric_limits<result_type>::infinity();
-      return (math::pow((1 - x), -1 / p.gamma()) - 1) * p.theta();
+      return (math::pow((1 - x), -1 / P.gamma()) - 1) * P.theta();
     }
   };
 
@@ -174,15 +172,15 @@ namespace trng {
 
   // EqualityComparable concept
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator==(const typename pareto_dist<float_t>::param_type &p1,
-                                          const typename pareto_dist<float_t>::param_type &p2) {
-    return p1.gamma() == p2.gamma() and p1.theta() == p2.theta();
+  TRNG_CUDA_ENABLE inline bool operator==(const typename pareto_dist<float_t>::param_type &P1,
+                                          const typename pareto_dist<float_t>::param_type &P2) {
+    return P1.gamma() == P2.gamma() and P1.theta() == P2.theta();
   }
 
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator!=(const typename pareto_dist<float_t>::param_type &p1,
-                                          const typename pareto_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+  TRNG_CUDA_ENABLE inline bool operator!=(const typename pareto_dist<float_t>::param_type &P1,
+                                          const typename pareto_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -214,12 +212,12 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    pareto_dist<float_t> &g) {
-    typename pareto_dist<float_t>::param_type p;
+    typename pareto_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[pareto ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[pareto ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/powerlaw_dist.hpp
+++ b/inst/include/trng/powerlaw_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -50,12 +50,11 @@ namespace trng {
   template<typename float_t = double>
   class powerlaw_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type gamma_, theta_;
+      result_type gamma_{1}, theta_{1};
 
     public:
       TRNG_CUDA_ENABLE
@@ -67,55 +66,56 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void theta(result_type theta_new) { theta_ = theta_new; }
       TRNG_CUDA_ENABLE
-      param_type() : gamma_(1), theta_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(result_type gamma, result_type theta) : gamma_(gamma), theta_(theta) {}
+      explicit param_type(result_type gamma, result_type theta)
+          : gamma_{gamma}, theta_{theta} {}
 
       friend class powerlaw_dist;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1)
-            << p.gamma() << ' ' << p.theta() << ')';
+            << P.gamma() << ' ' << P.theta() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t gamma, theta;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> gamma >> utility::delim(' ') >> theta >>
             utility::delim(')');
         if (in)
-          p = param_type(gamma, theta);
+          P = param_type(gamma, theta);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    powerlaw_dist(result_type gamma, result_type theta) : p(gamma, theta) {}
+    explicit powerlaw_dist(result_type gamma, result_type theta) : P{gamma, theta} {}
     TRNG_CUDA_ENABLE
-    explicit powerlaw_dist(const param_type &p) : p(p) {}
+    explicit powerlaw_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
     // random numbers
     template<typename R>
     TRNG_CUDA_ENABLE result_type operator()(R &r) {
-      return p.theta() * math::pow(utility::uniformoc<result_type>(r), -1 / p.gamma());
+      return P.theta() * math::pow(utility::uniformoc<result_type>(r), -1 / P.gamma());
     }
     template<typename R>
     TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
@@ -124,36 +124,34 @@ namespace trng {
     }
     // property methods
     TRNG_CUDA_ENABLE
-    result_type min() const { return p.theta(); }
+    result_type min() const { return P.theta(); }
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &p_new) { P = p_new; }
     TRNG_CUDA_ENABLE
-    result_type gamma() const { return p.gamma(); }
+    result_type gamma() const { return P.gamma(); }
     TRNG_CUDA_ENABLE
-    void gamma(result_type gamma_new) { p.gamma(gamma_new); }
+    void gamma(result_type gamma_new) { P.gamma(gamma_new); }
     TRNG_CUDA_ENABLE
-    result_type theta() const { return p.theta(); }
+    result_type theta() const { return P.theta(); }
     TRNG_CUDA_ENABLE
-    void theta(result_type theta_new) { p.theta(theta_new); }
+    void theta(result_type theta_new) { P.theta(theta_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
-      if (x < p.theta())
+      if (x < P.theta())
         return 0;
-      else
-        return p.gamma() / p.theta() * math::pow(x / p.theta(), -p.gamma() - 1);
+      return P.gamma() / P.theta() * math::pow(x / P.theta(), -P.gamma() - 1);
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
       if (x <= 0)
         return 0;
-      else
-        return 1 - math::pow(x / p.theta(), -p.gamma());
+      return 1 - math::pow(x / P.theta(), -P.gamma());
     }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
@@ -165,10 +163,10 @@ namespace trng {
         return math::numeric_limits<result_type>::quiet_NaN();
       }
       if (x == 0)
-        return p.theta();
+        return P.theta();
       if (x == 1)
         return math::numeric_limits<result_type>::infinity();
-      return p.theta() * math::pow(1 - x, -1 / p.gamma());
+      return P.theta() * math::pow(1 - x, -1 / P.gamma());
     }
   };
 

--- a/inst/include/trng/rayleigh_dist.hpp
+++ b/inst/include/trng/rayleigh_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -50,12 +50,11 @@ namespace trng {
   template<typename float_t = double>
   class rayleigh_dist {
   public:
-    typedef double result_type;
-    class param_type;
+    using result_type = double;
 
     class param_type {
     private:
-      result_type nu_;
+      result_type nu_{1};
 
     public:
       TRNG_CUDA_ENABLE
@@ -63,7 +62,7 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void nu(result_type nu_new) { nu_ = nu_new; }
       TRNG_CUDA_ENABLE
-      param_type() : nu_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
       explicit param_type(result_type nu) : nu_(nu) {}
 
@@ -72,10 +71,10 @@ namespace trng {
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << p.nu()
+        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << P.nu()
             << ')';
         out.flags(flags);
         return out;
@@ -83,27 +82,27 @@ namespace trng {
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t nu;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> nu >> utility::delim(')');
         if (in)
-          p = rayleigh_dist::param_type(nu);
+          P = rayleigh_dist::param_type(nu);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    explicit rayleigh_dist(result_type nu) : p(nu) {}
+    explicit rayleigh_dist(result_type nu) : P{nu} {}
     TRNG_CUDA_ENABLE
-    explicit rayleigh_dist(const param_type &p) : p(p) {}
+    explicit rayleigh_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -113,8 +112,8 @@ namespace trng {
       return icdf(utility::uniformoo<result_type>(r));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      rayleigh_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      rayleigh_dist g(P);
       return g(r);
     }
     // property methods
@@ -123,19 +122,19 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &p_new) { P = p_new; }
     TRNG_CUDA_ENABLE
-    result_type nu() const { return p.nu(); }
+    result_type nu() const { return P.nu(); }
     TRNG_CUDA_ENABLE
-    void nu(result_type nu_new) { p.nu(nu_new); }
+    void nu(result_type nu_new) { P.nu(nu_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
       if (x <= 0)
         return 0;
-      result_type t = x / (p.nu() * p.nu());
+      const result_type t{x / (P.nu() * P.nu())};
       return t * math::exp(-t * x / 2);
     }
     // cumulative density function
@@ -143,7 +142,7 @@ namespace trng {
     result_type cdf(result_type x) const {
       if (x <= 0)
         return 0;
-      return 1 - math::exp(-x * x / (2 * p.nu() * p.nu()));
+      return 1 - math::exp(-x * x / (2 * P.nu() * P.nu()));
     }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
@@ -154,7 +153,7 @@ namespace trng {
 #endif
         return math::numeric_limits<result_type>::quiet_NaN();
       }
-      return p.nu() * math::sqrt(-2 * math::ln(1 - x));
+      return P.nu() * math::sqrt(-2 * math::ln(1 - x));
     }
   };
 

--- a/inst/include/trng/snedecor_f_dist.hpp
+++ b/inst/include/trng/snedecor_f_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -51,12 +51,11 @@ namespace trng {
   template<typename float_t = double>
   class snedecor_f_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      int n_, m_;
+      int n_{1}, m_{1};
 
     public:
       TRNG_CUDA_ENABLE
@@ -68,54 +67,54 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void m(int m_new) { m_ = m_new; }
       TRNG_CUDA_ENABLE
-      param_type() : n_(1), m_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(int n, int m) : n_(n), m_(m) {}
+      explicit param_type(int n, int m) : n_{n}, m_{m} {}
 
       friend class snedecor_f_dist;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << p.n() << ' ' << p.m() << ')';
+        out << '(' << P.n() << ' ' << P.m() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         int n, m;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> n >> utility::delim(' ') >> m >> utility::delim(')');
         if (in)
-          p = snedecor_f_dist::param_type(n, m);
+          P = snedecor_f_dist::param_type(n, m);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
     result_type icdf_(result_type x) const {
-      result_type t = math::inv_Beta_I(x, result_type(1) / result_type(2) * p.n(),
-                                       result_type(1) / result_type(2) * p.m());
-      return t / (1 - t) * static_cast<result_type>(p.m()) / static_cast<result_type>(p.n());
+      const result_type t{math::inv_Beta_I(x, result_type(1) / result_type(2) * P.n(),
+                                           result_type(1) / result_type(2) * P.m())};
+      return t / (1 - t) * static_cast<result_type>(P.m()) / static_cast<result_type>(P.n());
     }
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    snedecor_f_dist(int n, int m) : p(n, m) {}
+    explicit snedecor_f_dist(int n, int m) : P{n, m} {}
     TRNG_CUDA_ENABLE
-    explicit snedecor_f_dist(const param_type &p) : p(p) {}
+    explicit snedecor_f_dist(const param_type &P) : P{P} {}
     // reset internal state
     void reset() {}
     // random numbers
@@ -124,8 +123,8 @@ namespace trng {
       return icdf_(utility::uniformco<result_type>(r));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      snedecor_f_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      snedecor_f_dist g(P);
       return g(r);
     }
     // property methods
@@ -133,22 +132,22 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &p_new) { P = p_new; }
     TRNG_CUDA_ENABLE
-    int n() const { return p.n(); }
+    int n() const { return P.n(); }
     TRNG_CUDA_ENABLE
-    void n(int n_new) { p.n(n_new); }
+    void n(int n_new) { P.n(n_new); }
     TRNG_CUDA_ENABLE
-    int m() const { return p.m(); }
+    int m() const { return P.m(); }
     TRNG_CUDA_ENABLE
-    void m(int m_new) { p.m(m_new); }
+    void m(int m_new) { P.m(m_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
-      const result_type n = static_cast<result_type>(p.n()),
-                        m = static_cast<result_type>(p.m());
+      const result_type n{static_cast<result_type>(P.n())};
+      const result_type m{static_cast<result_type>(P.m())};
       // return math::exp(math::ln(n)*result_type(1)/result_type(2)*n +
       // math::ln(m)*result_type(1)/result_type(2)*m -
       // 		       math::ln(m+n*x)*result_type(1)/result_type(2)*(m+n) +
@@ -165,8 +164,8 @@ namespace trng {
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
-      const result_type n = static_cast<result_type>(p.n()),
-                        m = static_cast<result_type>(p.m());
+      const result_type n{static_cast<result_type>(P.n())};
+      const result_type m{static_cast<result_type>(P.m())};
       return math::Beta_I(n * x / (m + n * x), result_type(1) / result_type(2) * n,
                           result_type(1) / result_type(2) * m);
     }
@@ -192,16 +191,16 @@ namespace trng {
   // EqualityComparable concept
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator==(
-      const typename snedecor_f_dist<float_t>::param_type &p1,
-      const typename snedecor_f_dist<float_t>::param_type &p2) {
-    return p1.n() == p2.n() and p1.m() == p2.m();
+      const typename snedecor_f_dist<float_t>::param_type &P1,
+      const typename snedecor_f_dist<float_t>::param_type &P2) {
+    return P1.n() == P2.n() and P1.m() == P2.m();
   }
 
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator!=(
-      const typename snedecor_f_dist<float_t>::param_type &p1,
-      const typename snedecor_f_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+      const typename snedecor_f_dist<float_t>::param_type &P1,
+      const typename snedecor_f_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -233,13 +232,13 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    snedecor_f_dist<float_t> &g) {
-    typename snedecor_f_dist<float_t>::param_type p;
+    typename snedecor_f_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[snedecor_f ") >> p >>
+    in >> utility::ignore_spaces() >> utility::delim("[snedecor_f ") >> P >>
         utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/student_t_dist.hpp
+++ b/inst/include/trng/student_t_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -51,12 +51,11 @@ namespace trng {
   template<typename float_t = double>
   class student_t_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      int nu_;
+      int nu_{1};
 
     public:
       TRNG_CUDA_ENABLE
@@ -64,7 +63,7 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void nu(int nu_new) { nu_ = nu_new; }
       TRNG_CUDA_ENABLE
-      param_type() : nu_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
       explicit param_type(int nu) : nu_(nu) {}
 
@@ -73,44 +72,45 @@ namespace trng {
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << p.nu() << ')';
+        out << '(' << P.nu() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         int nu;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> nu >> utility::delim(')');
         if (in)
-          p = param_type(nu);
+          P = param_type(nu);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
     result_type icdf_(result_type x) const {
-      result_type t = math::inv_Beta_I(x, p.nu() / result_type(2), p.nu() / result_type(2));
-      return math::sqrt(p.nu() / (t * (1 - t))) * (t - result_type(1) / result_type(2));
+      const result_type t{
+          math::inv_Beta_I(x, P.nu() / result_type(2), P.nu() / result_type(2))};
+      return math::sqrt(P.nu() / (t * (1 - t))) * (t - result_type(1) / result_type(2));
     }
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    explicit student_t_dist(int nu) : p(nu) {}
+    explicit student_t_dist(int nu) : P{nu} {}
     TRNG_CUDA_ENABLE
-    explicit student_t_dist(const param_type &p) : p(p) {}
+    explicit student_t_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -120,8 +120,8 @@ namespace trng {
       return icdf_(utility::uniformoo<result_type>(r));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      student_t_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      student_t_dist g(P);
       return g(r);
     }
     // property methods
@@ -130,27 +130,27 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &p_new) { P = p_new; }
     TRNG_CUDA_ENABLE
-    int nu() const { return p.nu(); }
+    int nu() const { return P.nu(); }
     TRNG_CUDA_ENABLE
-    void nu(int nu_new) { p.nu(nu_new); }
+    void nu(int nu_new) { P.nu(nu_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
-      result_type norm = math::exp(math::ln_Gamma((p.nu() + 1) / result_type(2)) -
-                                   math::ln_Gamma(p.nu() / result_type(2))) /
-                         math::sqrt(math::constants<result_type>::pi() * p.nu());
-      return norm * math::pow(1 + x * x / p.nu(), (p.nu() + 1) / result_type(-2));
+      const result_type norm{math::exp(math::ln_Gamma((P.nu() + 1) / result_type(2)) -
+                                       math::ln_Gamma(P.nu() / result_type(2))) /
+                             math::sqrt(math::constants<result_type>::pi * P.nu())};
+      return norm * math::pow(1 + x * x / P.nu(), (P.nu() + 1) / result_type(-2));
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
-      result_type t1 = +math::sqrt(x * x + p.nu());
-      result_type t2 = (x + t1) / (2 * t1);
-      return math::Beta_I(t2, p.nu() / result_type(2), p.nu() / result_type(2));
+      const result_type t1{+math::sqrt(x * x + P.nu())};
+      const result_type t2{(x + t1) / (2 * t1)};
+      return math::Beta_I(t2, P.nu() / result_type(2), P.nu() / result_type(2));
     }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
@@ -174,16 +174,16 @@ namespace trng {
   // EqualityComparable concept
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator==(
-      const typename student_t_dist<float_t>::param_type &p1,
-      const typename student_t_dist<float_t>::param_type &p2) {
-    return p1.nu() == p2.nu();
+      const typename student_t_dist<float_t>::param_type &P1,
+      const typename student_t_dist<float_t>::param_type &P2) {
+    return P1.nu() == P2.nu();
   }
 
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator!=(
-      const typename student_t_dist<float_t>::param_type &p1,
-      const typename student_t_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+      const typename student_t_dist<float_t>::param_type &P1,
+      const typename student_t_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -215,12 +215,12 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    student_t_dist<float_t> &g) {
-    typename student_t_dist<float_t>::param_type p;
+    typename student_t_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[student_t ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[student_t ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/tent_dist.hpp
+++ b/inst/include/trng/tent_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -50,12 +50,11 @@ namespace trng {
   template<typename float_t = double>
   class tent_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type m_, d_;
+      result_type m_{0}, d_{1};
 
     public:
       TRNG_CUDA_ENABLE
@@ -67,53 +66,53 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void d(result_type d_new) { d_ = d_new; }
       TRNG_CUDA_ENABLE
-      param_type() : m_(0), d_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(result_type m, result_type d) : m_(m), d_(d) {}
+      explicit param_type(result_type m, result_type d) : m_{m}, d_{d} {}
 
       friend class tent_dist;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << p.m()
-            << ' ' << p.d() << ')';
+        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << P.m()
+            << ' ' << P.d() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t m, d;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> m >> utility::delim(' ') >> d >> utility::delim(')');
         if (in)
-          p = param_type(m, d);
+          P = param_type(m, d);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
     TRNG_CUDA_ENABLE
     result_type icdf_(result_type x) const {
-      return x < result_type(1) / result_type(2) ? (-1 + math::sqrt(2 * x)) * p.d() + p.m()
-                                                 : (1 - math::sqrt(2 - 2 * x)) * p.d() + p.m();
+      return x < result_type(1) / result_type(2) ? (-1 + math::sqrt(2 * x)) * P.d() + P.m()
+                                                 : (1 - math::sqrt(2 - 2 * x)) * P.d() + P.m();
     }
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    tent_dist(result_type m, result_type d) : p(m, d) {}
+    explicit tent_dist(result_type m, result_type d) : P{m, d} {}
     TRNG_CUDA_ENABLE
-    explicit tent_dist(const param_type &p) : p(p) {}
+    explicit tent_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -123,45 +122,45 @@ namespace trng {
       return icdf_(utility::uniformcc<result_type>(r));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      tent_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      tent_dist g(P);
       return g(r);
     }
     // property methods
     TRNG_CUDA_ENABLE
-    result_type min() const { return p.m() - p.d(); }
+    result_type min() const { return P.m() - P.d(); }
     TRNG_CUDA_ENABLE
-    result_type max() const { return p.m() + p.d(); }
+    result_type max() const { return P.m() + P.d(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &p_new) { P = p_new; }
     TRNG_CUDA_ENABLE
-    result_type m() const { return p.m(); }
+    result_type m() const { return P.m(); }
     TRNG_CUDA_ENABLE
-    void m(result_type m_new) { p.m(m_new); }
+    void m(result_type m_new) { P.m(m_new); }
     TRNG_CUDA_ENABLE
-    result_type d() const { return p.d(); }
+    result_type d() const { return P.d(); }
     TRNG_CUDA_ENABLE
-    void d(result_type d_new) { p.d(d_new); }
+    void d(result_type d_new) { P.d(d_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
-      x -= p.m();
-      if (x <= -p.d() or x >= p.d())
+      x -= P.m();
+      if (x <= -P.d() or x >= P.d())
         return 0;
-      return x < 0 ? (1 + x / p.d()) / p.d() : (1 - x / p.d()) / p.d();
+      return x < 0 ? (1 + x / P.d()) / P.d() : (1 - x / P.d()) / P.d();
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
-      x -= p.m();
-      if (x <= -p.d())
+      x -= P.m();
+      if (x <= -P.d())
         return 0;
       if (x <= 0)
-        return (x + p.d()) * (x + p.d()) / (result_type(2) * p.d() * p.d());
-      if (x < p.d())
-        return 1 - (x - p.d()) * (x - p.d()) / (result_type(2) * p.d() * p.d());
+        return (x + P.d()) * (x + P.d()) / (result_type(2) * P.d() * P.d());
+      if (x < P.d())
+        return 1 - (x - P.d()) * (x - P.d()) / (result_type(2) * P.d() * P.d());
       return 1;
     }
     // inverse cumulative density function
@@ -181,15 +180,15 @@ namespace trng {
 
   // EqualityComparable concept
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator==(const typename tent_dist<float_t>::param_type &p1,
-                                          const typename tent_dist<float_t>::param_type &p2) {
-    return p1.m() == p2.m() and p1.d() == p2.d();
+  TRNG_CUDA_ENABLE inline bool operator==(const typename tent_dist<float_t>::param_type &P1,
+                                          const typename tent_dist<float_t>::param_type &P2) {
+    return P1.m() == P2.m() and P1.d() == P2.d();
   }
 
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator!=(const typename tent_dist<float_t>::param_type &p1,
-                                          const typename tent_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+  TRNG_CUDA_ENABLE inline bool operator!=(const typename tent_dist<float_t>::param_type &P1,
+                                          const typename tent_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -221,12 +220,12 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    tent_dist<float_t> &g) {
-    typename tent_dist<float_t>::param_type p;
+    typename tent_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[tent ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[tent ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/truncated_normal_dist.hpp
+++ b/inst/include/trng/truncated_normal_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -51,12 +51,12 @@ namespace trng {
   template<typename float_t = double>
   class truncated_normal_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type mu_, sigma_, a_, b_, Phi_a, Phi_b;
+      result_type mu_{0}, sigma_{1}, a_{-math::numeric_limits<result_type>::infinity()},
+          b_{math::numeric_limits<result_type>::infinity()}, Phi_a{0}, Phi_b{1};
 
       TRNG_CUDA_ENABLE
       void update_Phi() {
@@ -100,16 +100,10 @@ namespace trng {
         update_Phi();
       }
       TRNG_CUDA_ENABLE
-      param_type()
-          : mu_(0),
-            sigma_(1),
-            a_(-math::numeric_limits<result_type>::infinity()),
-            b_(math::numeric_limits<result_type>::infinity()) {
-        update_Phi();
-      }
+      param_type() { update_Phi(); }
       TRNG_CUDA_ENABLE
-      param_type(result_type mu, result_type sigma, result_type a, result_type b)
-          : mu_(mu), sigma_(sigma), a_(a), b_(b) {
+      explicit param_type(result_type mu, result_type sigma, result_type a, result_type b)
+          : mu_{mu}, sigma_{sigma}, a_{a}, b_{b} {
         update_Phi();
       }
 
@@ -118,40 +112,41 @@ namespace trng {
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << p.mu()
-            << ' ' << p.sigma() << ' ' << p.a() << ' ' << p.b() << ')';
+        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << P.mu()
+            << ' ' << P.sigma() << ' ' << P.a() << ' ' << P.b() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t mu, sigma, a, b;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> mu >> utility::delim(' ') >> sigma >>
             utility::delim(' ') >> a >> utility::delim(' ') >> b >> utility::delim(')');
         if (in)
-          p = param_type(mu, sigma, a, b);
+          P = param_type(mu, sigma, a, b);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    truncated_normal_dist(result_type mu, result_type sigma, result_type a, result_type b)
-        : p(mu, sigma, a, b) {}
+    explicit truncated_normal_dist(result_type mu, result_type sigma, result_type a,
+                                   result_type b)
+        : P{mu, sigma, a, b} {}
     TRNG_CUDA_ENABLE
-    explicit truncated_normal_dist(const param_type &p) : p(p) {}
+    explicit truncated_normal_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -161,56 +156,56 @@ namespace trng {
       return icdf(utility::uniformoo<result_type>(r));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      truncated_normal_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      truncated_normal_dist g(P);
       return g(r);
     }
     // property methods
     TRNG_CUDA_ENABLE
-    result_type min() const { return p.a(); }
+    result_type min() const { return P.a(); }
     TRNG_CUDA_ENABLE
-    result_type max() const { return p.b(); }
+    result_type max() const { return P.b(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &p_new) { P = p_new; }
     TRNG_CUDA_ENABLE
-    result_type mu() const { return p.mu(); }
+    result_type mu() const { return P.mu(); }
     TRNG_CUDA_ENABLE
-    void mu(result_type mu_new) { p.mu(mu_new); }
+    void mu(result_type mu_new) { P.mu(mu_new); }
     TRNG_CUDA_ENABLE
-    result_type sigma() const { return p.sigma(); }
+    result_type sigma() const { return P.sigma(); }
     TRNG_CUDA_ENABLE
-    void sigma(result_type sigma_new) { p.sigma(sigma_new); }
+    void sigma(result_type sigma_new) { P.sigma(sigma_new); }
     TRNG_CUDA_ENABLE
-    result_type a() const { return p.a(); }
+    result_type a() const { return P.a(); }
     TRNG_CUDA_ENABLE
-    void a(result_type a_new) { p.a(a_new); }
+    void a(result_type a_new) { P.a(a_new); }
     TRNG_CUDA_ENABLE
-    result_type b() const { return p.b(); }
+    result_type b() const { return P.b(); }
     TRNG_CUDA_ENABLE
-    void b(result_type b_new) { p.b(b_new); }
+    void b(result_type b_new) { P.b(b_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
-      x -= p.mu();
-      x /= p.sigma();
-      return math::constants<result_type>::one_over_sqrt_2pi() / p.sigma() *
-             math::exp(-0.5 * x * x) / (p.Phi_b - p.Phi_a);
+      x -= P.mu();
+      x /= P.sigma();
+      return math::constants<result_type>::one_over_sqrt_2pi / P.sigma() *
+             math::exp(-0.5 * x * x) / (P.Phi_b - P.Phi_a);
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
-      x -= p.mu();
-      x /= p.sigma();
-      return (math::Phi(x) - p.Phi_a) / (p.Phi_b - p.Phi_a);
+      x -= P.mu();
+      x /= P.sigma();
+      return (math::Phi(x) - P.Phi_a) / (P.Phi_b - P.Phi_a);
     }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
     result_type icdf(result_type x) const {
-      x *= p.Phi_b - p.Phi_a;
-      x += p.Phi_a;
-      return math::inv_Phi(x) * p.sigma() + p.mu();
+      x *= P.Phi_b - P.Phi_a;
+      x += P.Phi_a;
+      return math::inv_Phi(x) * P.sigma() + P.mu();
     }
   };
 
@@ -219,16 +214,17 @@ namespace trng {
   // EqualityComparable concept
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator==(
-      const typename truncated_normal_dist<float_t>::param_type &p1,
-      const typename truncated_normal_dist<float_t>::param_type &p2) {
-    return p1.mu() == p2.mu() and p1.sigma() == p2.sigma();
+      const typename truncated_normal_dist<float_t>::param_type &P1,
+      const typename truncated_normal_dist<float_t>::param_type &P2) {
+    return P1.mu() == P2.mu() and P1.sigma() == P2.sigma() and P1.a() == P2.a() and
+           P1.b() == P2.b();
   }
 
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator!=(
-      const typename truncated_normal_dist<float_t>::param_type &p1,
-      const typename truncated_normal_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+      const typename truncated_normal_dist<float_t>::param_type &P1,
+      const typename truncated_normal_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -260,13 +256,13 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    truncated_normal_dist<float_t> &g) {
-    typename truncated_normal_dist<float_t>::param_type p;
+    typename truncated_normal_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[truncated_normal ") >> p >>
+    in >> utility::ignore_spaces() >> utility::delim("[truncated_normal ") >> P >>
         utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/twosided_exponential_dist.hpp
+++ b/inst/include/trng/twosided_exponential_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -51,12 +51,11 @@ namespace trng {
   template<typename float_t = double>
   class twosided_exponential_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type mu_;
+      result_type mu_{1};
 
     public:
       TRNG_CUDA_ENABLE
@@ -64,19 +63,19 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void mu(result_type mu_new) { mu_ = mu_new; }
       TRNG_CUDA_ENABLE
-      param_type() : mu_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
-      explicit param_type(result_type mu) : mu_(mu) {}
+      explicit param_type(result_type mu) : mu_{mu} {}
 
       friend class twosided_exponential_dist<result_type>;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << p.mu()
+        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << P.mu()
             << ')';
         out.flags(flags);
         return out;
@@ -84,27 +83,27 @@ namespace trng {
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t mu;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> mu >> utility::delim(')');
         if (in)
-          p = param_type(mu);
+          P = param_type(mu);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    explicit twosided_exponential_dist(result_type mu) : p(mu) {}
+    explicit twosided_exponential_dist(result_type mu) : P{mu} {}
     TRNG_CUDA_ENABLE
-    explicit twosided_exponential_dist(const param_type &p) : p(p) {}
+    explicit twosided_exponential_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -114,8 +113,8 @@ namespace trng {
       return icdf(utility::uniformoo<double>(r));
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      twosided_exponential_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      twosided_exponential_dist g(P);
       return g(r);
     }
     // property methods
@@ -124,22 +123,22 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &p_new) { P = p_new; }
     TRNG_CUDA_ENABLE
-    result_type mu() const { return p.mu(); }
+    result_type mu() const { return P.mu(); }
     TRNG_CUDA_ENABLE
-    void mu(result_type mu_new) { p.mu(mu_new); }
+    void mu(result_type mu_new) { P.mu(mu_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
-      return math::exp(-math::abs(x) / p.mu()) / (2 * p.mu());
+      return math::exp(-math::abs(x) / P.mu()) / (2 * P.mu());
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
-      return x <= 0 ? math::exp(x / p.mu()) / 2 : 1 - math::exp(-x / p.mu()) / 2;
+      return x <= 0 ? math::exp(x / P.mu()) / 2 : 1 - math::exp(-x / P.mu()) / 2;
     }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
@@ -154,8 +153,8 @@ namespace trng {
         return math::numeric_limits<result_type>::infinity();
       if (x == 0)
         return -math::numeric_limits<result_type>::infinity();
-      return x < math::constants<result_type>::one_half() ? p.mu() * math::ln(2 * x)
-                                                          : -p.mu() * math::ln(2 - 2 * x);
+      return x < math::constants<result_type>::one_half ? P.mu() * math::ln(2 * x)
+                                                        : -P.mu() * math::ln(2 - 2 * x);
     }
   };
 
@@ -164,16 +163,16 @@ namespace trng {
   // EqualityComparable concept
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator==(
-      const typename twosided_exponential_dist<float_t>::param_type &p1,
-      const typename twosided_exponential_dist<float_t>::param_type &p2) {
-    return p1.mu() == p2.mu();
+      const typename twosided_exponential_dist<float_t>::param_type &P1,
+      const typename twosided_exponential_dist<float_t>::param_type &P2) {
+    return P1.mu() == P2.mu();
   }
 
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator!=(
-      const typename twosided_exponential_dist<float_t>::param_type &p1,
-      const typename twosided_exponential_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+      const typename twosided_exponential_dist<float_t>::param_type &P1,
+      const typename twosided_exponential_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -205,13 +204,13 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    twosided_exponential_dist<float_t> &g) {
-    typename twosided_exponential_dist<float_t>::param_type p;
+    typename twosided_exponential_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[twosided exponential ") >> p >>
+    in >> utility::ignore_spaces() >> utility::delim("[twosided exponential ") >> P >>
         utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/uniform01_dist.hpp
+++ b/inst/include/trng/uniform01_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -48,20 +48,19 @@ namespace trng {
   template<typename float_t = double>
   class uniform01_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     public:
       TRNG_CUDA_ENABLE
-      param_type() {}
+      param_type() = default;
 
       friend class uniform01_dist<float_t>;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         out << '(' << ')';
@@ -71,7 +70,7 @@ namespace trng {
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &) {
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> utility::delim(')');
@@ -86,9 +85,9 @@ namespace trng {
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    uniform01_dist() {}
+    uniform01_dist() = default;
     TRNG_CUDA_ENABLE
-    explicit uniform01_dist(const param_type &p) {}
+    explicit uniform01_dist(const param_type &) {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
@@ -98,7 +97,7 @@ namespace trng {
       return utility::uniformco<result_type>(r);
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &) {
       return utility::uniformco<result_type>(r);
     }
     // property methods
@@ -110,7 +109,7 @@ namespace trng {
     TRNG_CUDA_ENABLE
     param_type param() const { return p; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) {}
+    void param(const param_type &) {}
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
@@ -186,12 +185,12 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    uniform01_dist<float_t> &g) {
-    typename uniform01_dist<float_t>::param_type p;
+    typename uniform01_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[uniform01 ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[uniform01 ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/uniform_dist.hpp
+++ b/inst/include/trng/uniform_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -49,12 +49,11 @@ namespace trng {
   template<typename float_t = double>
   class uniform_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type a_, b_, d_;
+      result_type a_{0}, b_{1}, d_{1};
       TRNG_CUDA_ENABLE
       result_type d() const { return d_; }
 
@@ -74,92 +73,92 @@ namespace trng {
         d_ = b_ - a_;
       }
       TRNG_CUDA_ENABLE
-      param_type() : a_(0), b_(1), d_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(result_type a, result_type b) : a_(a), b_(b), d_(b - a) {}
+      explicit param_type(result_type a, result_type b) : a_(a), b_(b), d_(b - a) {}
 
       friend class uniform_dist<float_t>;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << p.a()
-            << ' ' << p.b() << ')';
+        out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1) << P.a()
+            << ' ' << P.b() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t a, b;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> a >> utility::delim(' ') >> b >> utility::delim(')');
         if (in)
-          p = param_type(a, b);
+          P = param_type(a, b);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    uniform_dist(result_type a, result_type b) : p(a, b) {}
+    uniform_dist(result_type a, result_type b) : P{a, b} {}
     TRNG_CUDA_ENABLE
-    explicit uniform_dist(const param_type &p) : p(p) {}
+    explicit uniform_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
     // random numbers
     template<typename R>
     TRNG_CUDA_ENABLE result_type operator()(R &r) {
-      return p.d() * utility::uniformco<result_type>(r) + p.a();
+      return P.d() * utility::uniformco<result_type>(r) + P.a();
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      uniform_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      uniform_dist g(P);
       return g(r);
     }
     // property methods
     TRNG_CUDA_ENABLE
-    result_type min() const { return p.a(); }
+    result_type min() const { return P.a(); }
     TRNG_CUDA_ENABLE
-    result_type max() const { return p.b(); }
+    result_type max() const { return P.b(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &p_new) { P = p_new; }
     TRNG_CUDA_ENABLE
-    result_type a() const { return p.a(); }
+    result_type a() const { return P.a(); }
     TRNG_CUDA_ENABLE
-    void a(result_type a_new) { p.a(a_new); }
+    void a(result_type a_new) { P.a(a_new); }
     TRNG_CUDA_ENABLE
-    result_type b() const { return p.b(); }
+    result_type b() const { return P.b(); }
     TRNG_CUDA_ENABLE
-    void b(result_type b_new) { p.b(b_new); }
+    void b(result_type b_new) { P.b(b_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
-      if (x < p.a() or x >= p.b())
+      if (x < P.a() or x >= P.b())
         return 0.0;
-      return 1.0 / p.d();
+      return 1.0 / P.d();
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
-      if (x < p.a())
+      if (x < P.a())
         return 0;
-      if (x >= p.b())
+      if (x >= P.b())
         return 1;
-      return (x - p.a()) / p.d();
+      return (x - P.a()) / P.d();
     }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
@@ -170,7 +169,7 @@ namespace trng {
 #endif
         return math::numeric_limits<result_type>::quiet_NaN();
       }
-      return x * p.d() + p.a();
+      return x * P.d() + P.a();
     }
   };
 
@@ -178,31 +177,29 @@ namespace trng {
 
   // EqualityComparable concept
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator==(
-      const typename uniform_dist<float_t>::param_type &p1,
-      const typename uniform_dist<float_t>::param_type &p2) {
-    return p1.a() == p2.a() and p1.b() == p2.b();
+  TRNG_CUDA_ENABLE bool operator==(const typename uniform_dist<float_t>::param_type &P1,
+                                   const typename uniform_dist<float_t>::param_type &P2) {
+    return P1.a() == P2.a() and P1.b() == P2.b();
   }
 
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator!=(
-      const typename uniform_dist<float_t>::param_type &p1,
-      const typename uniform_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+  TRNG_CUDA_ENABLE bool operator!=(const typename uniform_dist<float_t>::param_type &P1,
+                                   const typename uniform_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
 
   // EqualityComparable concept
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator==(const uniform_dist<float_t> &g1,
-                                          const uniform_dist<float_t> &g2) {
+  TRNG_CUDA_ENABLE bool operator==(const uniform_dist<float_t> &g1,
+                                   const uniform_dist<float_t> &g2) {
     return g1.param() == g2.param();
   }
 
   template<typename float_t>
-  TRNG_CUDA_ENABLE inline bool operator!=(const uniform_dist<float_t> &g1,
-                                          const uniform_dist<float_t> &g2) {
+  TRNG_CUDA_ENABLE bool operator!=(const uniform_dist<float_t> &g1,
+                                   const uniform_dist<float_t> &g2) {
     return g1.param() != g2.param();
   }
 
@@ -222,12 +219,12 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    uniform_dist<float_t> &g) {
-    typename uniform_dist<float_t>::param_type p;
+    typename uniform_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[uniform ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[uniform ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/uniform_int_dist.hpp
+++ b/inst/include/trng/uniform_int_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -46,12 +46,11 @@ namespace trng {
   // uniform random number generator class
   class uniform_int_dist {
   public:
-    typedef int result_type;
-    class param_type;
+    using result_type = int;
 
     class param_type {
     private:
-      result_type a_, b_, d_;
+      result_type a_{0}, b_{1}, d_{1};
       TRNG_CUDA_ENABLE
       result_type d() const { return d_; }
 
@@ -71,67 +70,67 @@ namespace trng {
         d_ = b_ - a_;
       }
       TRNG_CUDA_ENABLE
-      param_type() : a_(0), b_(1), d_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(result_type a, result_type b) : a_(a), b_(b), d_(b - a) {}
+      explicit param_type(result_type a, result_type b) : a_(a), b_(b), d_(b - a) {}
 
       friend class uniform_int_dist;
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    uniform_int_dist(result_type a, result_type b) : p(a, b) {}
+    explicit uniform_int_dist(result_type a, result_type b) : P{a, b} {}
     TRNG_CUDA_ENABLE
-    explicit uniform_int_dist(const param_type &p) : p(p) {}
+    explicit uniform_int_dist(const param_type &P) : P{P} {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
     // random numbers
     template<typename R>
     TRNG_CUDA_ENABLE result_type operator()(R &r) {
-      return static_cast<result_type>(p.d() * utility::uniformco<double>(r)) + p.a();
+      return static_cast<result_type>(P.d() * utility::uniformco<double>(r)) + P.a();
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      uniform_int_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      uniform_int_dist g(P);
       return g(r);
     }
     // property methods
     TRNG_CUDA_ENABLE
-    result_type min() const { return p.a(); }
+    result_type min() const { return P.a(); }
     TRNG_CUDA_ENABLE
-    result_type max() const { return p.b() - 1; }
+    result_type max() const { return P.b() - 1; }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &p_new) { P = p_new; }
     TRNG_CUDA_ENABLE
-    result_type a() const { return p.a(); }
+    result_type a() const { return P.a(); }
     TRNG_CUDA_ENABLE
-    void a(result_type a_new) { p.a(a_new); }
+    void a(result_type a_new) { P.a(a_new); }
     TRNG_CUDA_ENABLE
-    result_type b() const { return p.b(); }
+    result_type b() const { return P.b(); }
     TRNG_CUDA_ENABLE
-    void b(result_type b_new) { p.b(b_new); }
+    void b(result_type b_new) { P.b(b_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     double pdf(result_type x) const {
-      if (x < p.a() or x >= p.b())
+      if (x < P.a() or x >= P.b())
         return 0.0;
-      return 1.0 / p.d();
+      return 1.0 / P.d();
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     double cdf(result_type x) const {
-      if (x < p.a())
+      if (x < P.a())
         return 0;
-      if (x >= p.b())
+      if (x >= P.b())
         return 1.0;
-      return (x - p.a() + 1) / p.d();
+      return static_cast<double>(x - P.a() + 1) / static_cast<double>(P.d());
     }
   };
 
@@ -139,36 +138,36 @@ namespace trng {
 
   // EqualityComparable concept
   TRNG_CUDA_ENABLE
-  inline bool operator==(const uniform_int_dist::param_type &p1,
-                         const uniform_int_dist::param_type &p2) {
-    return p1.a() == p2.a() and p1.b() == p2.b();
+  bool operator==(const uniform_int_dist::param_type &P1,
+                  const uniform_int_dist::param_type &P2) {
+    return P1.a() == P2.a() and P1.b() == P2.b();
   }
   TRNG_CUDA_ENABLE
-  inline bool operator!=(const uniform_int_dist::param_type &p1,
-                         const uniform_int_dist::param_type &p2) {
-    return not(p1 == p2);
+  bool operator!=(const uniform_int_dist::param_type &P1,
+                  const uniform_int_dist::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // Streamable concept
   template<typename char_t, typename traits_t>
   std::basic_ostream<char_t, traits_t> &operator<<(std::basic_ostream<char_t, traits_t> &out,
-                                                   const uniform_int_dist::param_type &p) {
+                                                   const uniform_int_dist::param_type &P) {
     std::ios_base::fmtflags flags(out.flags());
     out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    out << '(' << p.a() << ' ' << p.b() << ')';
+    out << '(' << P.a() << ' ' << P.b() << ')';
     out.flags(flags);
     return out;
   }
 
   template<typename char_t, typename traits_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
-                                                   uniform_int_dist::param_type &p) {
+                                                   uniform_int_dist::param_type &P) {
     int a, b;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
     in >> utility::delim('(') >> a >> utility::delim(' ') >> b >> utility::delim(')');
     if (in)
-      p = uniform_int_dist::param_type(a, b);
+      P = uniform_int_dist::param_type(a, b);
     in.flags(flags);
     return in;
   }
@@ -177,11 +176,11 @@ namespace trng {
 
   // EqualityComparable concept
   TRNG_CUDA_ENABLE
-  inline bool operator==(const uniform_int_dist &g1, const uniform_int_dist &g2) {
+  bool operator==(const uniform_int_dist &g1, const uniform_int_dist &g2) {
     return g1.param() == g2.param();
   }
   TRNG_CUDA_ENABLE
-  inline bool operator!=(const uniform_int_dist &g1, const uniform_int_dist &g2) {
+  bool operator!=(const uniform_int_dist &g1, const uniform_int_dist &g2) {
     return g1.param() != g2.param();
   }
 
@@ -199,13 +198,13 @@ namespace trng {
   template<typename char_t, typename traits_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    uniform_int_dist &g) {
-    uniform_int_dist::param_type p;
+    uniform_int_dist::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[uniform_int ") >> p >>
+    in >> utility::ignore_spaces() >> utility::delim("[uniform_int ") >> P >>
         utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/uniformxx.hpp
+++ b/inst/include/trng/uniformxx.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,10 +34,10 @@
 #if !(defined TRNG_UNIFORMXX_HPP)
 #define TRNG_UNIFORMXX_HPP
 
-#include <cstddef>
-#include <cfloat>
 #include <trng/cuda.hpp>
 #include <trng/limits.hpp>
+#include <cstddef>
+#include <cfloat>
 #include <ciso646>
 
 namespace trng {
@@ -46,24 +46,24 @@ namespace trng {
 
     template<unsigned long long top, unsigned int count = 0>
     struct Bits {
-      enum { result = Bits<top / 2, count + 1>::result };
+      static constexpr unsigned int result = Bits<top / 2, count + 1>::result;
     };
 
     template<unsigned int count>
-    struct Bits<0ULL, count> {
-      enum { result = count };
+    struct Bits<0ull, count> {
+      static constexpr unsigned int result = count;
     };
 
     //------------------------------------------------------------------
 
     template<unsigned long long top, unsigned int count = 0>
     struct Holes {
-      enum { result = Holes<top / 2, count + (~top & 1)>::result };
+      static constexpr unsigned int result = Holes<top / 2, count + (~top & 1u)>::result;
     };
 
     template<unsigned int count>
-    struct Holes<0ULL, count> {
-      enum { result = count };
+    struct Holes<0ull, count> {
+      static constexpr unsigned int result = count;
     };
 
     //------------------------------------------------------------------
@@ -77,7 +77,7 @@ namespace trng {
 #if !(defined __CUDA_ARCH__)
       static
 #endif
-          float
+          constexpr float
           val() {
         return FLT_EPSILON;
       }
@@ -89,7 +89,7 @@ namespace trng {
 #if !(defined __CUDA_ARCH__)
       static
 #endif
-          double
+          constexpr double
           val() {
         return DBL_EPSILON;
       }
@@ -101,7 +101,7 @@ namespace trng {
 #if !(defined __CUDA_ARCH__)
       static
 #endif
-          long double
+          constexpr long double
           val() {
         return LDBL_EPSILON;
       }
@@ -114,39 +114,40 @@ namespace trng {
     // They should also collapse the size (sizeof(u01xx_traits<...>) to 1.
     template<typename return_type, std::size_t requested_bits, typename prng_t>
     class u01xx_traits {
-      typedef return_type ret_t;
-      typedef typename prng_t::result_type result_type;
+      using ret_t = return_type;
+      using result_type = typename prng_t::result_type;
 
       // Casting up from "simpler" types may yield better low level code sequences.
-      static const result_type domain_max0 = prng_t::max() - prng_t::min();
-      static const unsigned int domain_bits = Bits<domain_max0>::result;
-      static const unsigned int domain_full_bits =
+      static constexpr result_type domain_max0 = prng_t::max() - prng_t::min();
+      static constexpr unsigned int domain_bits = Bits<domain_max0>::result;
+      static constexpr unsigned int domain_full_bits =
           domain_bits - (Holes<domain_max0>::result > 0);
-      static const bool int_ok =
+      static constexpr bool int_ok =
           domain_bits < static_cast<unsigned int>(math::numeric_limits<unsigned int>::digits);
-      static const bool long_ok =
+      static constexpr bool long_ok =
           domain_bits < static_cast<unsigned int>(math::numeric_limits<unsigned long>::digits);
-      static const bool long_long_ok =
+      static constexpr bool long_long_ok =
           domain_bits <
           static_cast<unsigned int>(math::numeric_limits<unsigned long long>::digits);
 
-      static const unsigned int ret_bits = math::numeric_limits<ret_t>::digits;
-      static const unsigned int bits0 = (requested_bits < ret_bits) ? requested_bits : ret_bits;
-      static const unsigned int bits = (bits0 < 1) ? 1 : bits0;
-      static const std::size_t calls_needed =
+      static constexpr unsigned int ret_bits = math::numeric_limits<ret_t>::digits;
+      static constexpr unsigned int bits0 =
+          (requested_bits < ret_bits) ? requested_bits : ret_bits;
+      static constexpr unsigned int bits = (bits0 < 1) ? 1 : bits0;
+      static constexpr std::size_t calls_needed =
           (bits / domain_full_bits) + ((bits % domain_full_bits) != 0);
 
       // a ((long long)(val >> 1)) cast may give us better performance (~4X using lcg on Core2
       // x86-64) the lost bit will not usually be missed as it is ~30dB down typically (53 bit
       // mantissa from a 63 rather than 64 bit integer variate)
-      static const bool use_ll_of_shifted =
-          not long_long_ok and (domain_max0 >> 1) == (~0ULL >> 1) and bits < domain_bits;
-      static const result_type domain_max =
-          use_ll_of_shifted ? (domain_max0 >> 1) : domain_max0;
+      static constexpr bool use_ll_of_shifted =
+          not long_long_ok and (domain_max0 >> 1u) == (~0ULL >> 1u) and bits < domain_bits;
+      static constexpr result_type domain_max =
+          use_ll_of_shifted ? (domain_max0 >> 1u) : domain_max0;
 
       TRNG_CUDA_ENABLE
       static ret_t addin(prng_t &r) {
-        result_type x = r() - prng_t::min();
+        const result_type x{r() - prng_t::min()};
         if (int_ok)
           return static_cast<ret_t>(static_cast<int>(x));
         else if (long_ok)
@@ -160,10 +161,10 @@ namespace trng {
       }
       TRNG_CUDA_ENABLE
       static ret_t variate_max() {
-        const ret_t scale_per_step(static_cast<ret_t>(domain_max) + 1);
-        const ret_t max_addin(static_cast<ret_t>(domain_max));
-        ret_t ret(max_addin);
-        for (std::size_t i(1); i < calls_needed; ++i)
+        const ret_t scale_per_step{static_cast<ret_t>(domain_max) + 1};
+        const ret_t max_addin{static_cast<ret_t>(domain_max)};
+        ret_t ret{max_addin};
+        for (std::size_t i{1}; i < calls_needed; ++i)
           ret = ret * scale_per_step + max_addin;
         return ret;
       }
@@ -171,15 +172,15 @@ namespace trng {
       static ret_t variate(prng_t &r) {
 #if !(defined __CUDA_ARCH__)
         static_assert(prng_t::min() >= 0 and prng_t::max() > prng_t::min(),
-                      "");  // min and/or max out of spec?
-        static_assert(prng_t::max() - prng_t::min() <= ~0ULL,
-                      "");  // Bits, Holes incorrect otherwise
-        static_assert(not math::numeric_limits<return_type>::is_integer, "");
-        static_assert(calls_needed > 0 and calls_needed <= bits, "");
+                      "min max out of range");  // min and/or max out of spec?
+        static_assert(prng_t::max() - prng_t::min() <= ~0ull,
+                      "min max have exotic values/types");  // Bits, Holes incorrect otherwise
+        static_assert(not math::numeric_limits<return_type>::is_integer, "not an integer");
+        static_assert(calls_needed > 0 and calls_needed <= bits, "illegal number of calls");
 #endif
         const ret_t scale_per_step(ret_t(domain_max) + 1);
-        ret_t ret(addin(r));
-        for (std::size_t i(1); i < calls_needed; ++i)
+        ret_t ret{addin(r)};
+        for (std::size_t i{1}; i < calls_needed; ++i)
           ret = ret * scale_per_step + addin(r);
         return ret;
       }
@@ -189,9 +190,9 @@ namespace trng {
         epsilon<ret_t> EPS;
         const ret_t native_eps(EPS.val());
 #else
-        const ret_t native_eps(epsilon<ret_t>::val());
+        const ret_t native_eps{epsilon<ret_t>::val()};
 #endif
-        const ret_t domain_eps(ret_t(1) / domain_max);
+        const ret_t domain_eps{ret_t(1) / domain_max};
         return native_eps >= domain_eps or requested_bits != 1 ? native_eps : domain_eps;
       }
       TRNG_CUDA_ENABLE
@@ -204,7 +205,7 @@ namespace trng {
     public:
       TRNG_CUDA_ENABLE
       static return_type cc(prng_t &r) {
-        const bool division_required(variate_max() * cc_norm() != 1);
+        const bool division_required{variate_max() * cc_norm() != 1};
         return division_required ? variate(r) / variate_max() : variate(r) * cc_norm();
       }
       TRNG_CUDA_ENABLE

--- a/inst/include/trng/utility.hpp
+++ b/inst/include/trng/utility.hpp
@@ -89,9 +89,9 @@ namespace trng {
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
           std::basic_istream<char_t, traits_t> &in, const delim_str &d) {
-        char c;
+        char c{0};
         std::size_t len{std::strlen(d.str)}, i{0};
-        while (i < len and !(in.get(c) and c != d.str[i])) {
+        while (i < len and not(in.get(c) and c != d.str[i])) {
           ++i;
         }
         if (i < len)
@@ -108,9 +108,8 @@ namespace trng {
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
           std::basic_istream<char_t, traits_t> &in, const delim_c &d) {
-        char c;
-        in.get(c);
-        if (c != d.c)
+        char c{0};
+        if (not in.get(c).good() or c != d.c)
           in.setstate(std::ios::failbit);
         return in;
       }
@@ -127,9 +126,9 @@ namespace trng {
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
           std::basic_istream<char_t, traits_t> &in, const ignore_spaces_cl &) {
-        while (true) {
+        while (in.good()) {
           const int c(in.peek());
-          if (c == EOF or !(c == ' ' or c == '\t' or c == '\n'))
+          if (c == traits_t::eof() or not(c == ' ' or c == '\t' or c == '\n'))
             break;
           in.get();
         }

--- a/inst/include/trng/weibull_dist.hpp
+++ b/inst/include/trng/weibull_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -50,12 +50,11 @@ namespace trng {
   template<typename float_t = double>
   class weibull_dist {
   public:
-    typedef float_t result_type;
-    class param_type;
+    using result_type = float_t;
 
     class param_type {
     private:
-      result_type theta_, beta_;
+      result_type theta_{1}, beta_{1};
 
     public:
       TRNG_CUDA_ENABLE
@@ -67,59 +66,59 @@ namespace trng {
       TRNG_CUDA_ENABLE
       void beta(result_type beta_new) { beta_ = beta_new; }
       TRNG_CUDA_ENABLE
-      param_type() : theta_(1), beta_(1) {}
+      param_type() = default;
       TRNG_CUDA_ENABLE
-      param_type(result_type theta, result_type beta) : theta_(theta), beta_(beta) {}
+      explicit param_type(result_type theta, result_type beta) : theta_(theta), beta_(beta) {}
 
       friend class weibull_dist;
 
       // Streamable concept
       template<typename char_t, typename traits_t>
       friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const param_type &p) {
+          std::basic_ostream<char_t, traits_t> &out, const param_type &P) {
         std::ios_base::fmtflags flags(out.flags());
         out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         out << '(' << std::setprecision(math::numeric_limits<float_t>::digits10 + 1)
-            << p.theta() << ' ' << p.beta() << ')';
+            << P.theta() << ' ' << P.beta() << ')';
         out.flags(flags);
         return out;
       }
 
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, param_type &p) {
+          std::basic_istream<char_t, traits_t> &in, param_type &P) {
         float_t theta, beta;
         std::ios_base::fmtflags flags(in.flags());
         in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
         in >> utility::delim('(') >> theta >> utility::delim(' ') >> beta >>
             utility::delim(')');
         if (in)
-          p = param_type(theta, beta);
+          P = param_type(theta, beta);
         in.flags(flags);
         return in;
       }
     };
 
   private:
-    param_type p;
+    param_type P;
 
   public:
     // constructor
     TRNG_CUDA_ENABLE
-    weibull_dist(result_type theta, result_type beta) : p(theta, beta) {}
+    weibull_dist(result_type theta, result_type beta) : P(theta, beta) {}
     TRNG_CUDA_ENABLE
-    explicit weibull_dist(const param_type &p) : p(p) {}
+    explicit weibull_dist(const param_type &P) : P(P) {}
     // reset internal state
     TRNG_CUDA_ENABLE
     void reset() {}
     // random numbers
     template<typename R>
     TRNG_CUDA_ENABLE result_type operator()(R &r) {
-      return p.theta() * math::pow(-math::ln(utility::uniformoc<result_type>(r)), 1 / p.beta());
+      return P.theta() * math::pow(-math::ln(utility::uniformoc<result_type>(r)), 1 / P.beta());
     }
     template<typename R>
-    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &p) {
-      weibull_dist g(p);
+    TRNG_CUDA_ENABLE result_type operator()(R &r, const param_type &P) {
+      weibull_dist g(P);
       return g(r);
     }
     // property methods
@@ -128,42 +127,42 @@ namespace trng {
     TRNG_CUDA_ENABLE
     result_type max() const { return math::numeric_limits<result_type>::infinity(); }
     TRNG_CUDA_ENABLE
-    param_type param() const { return p; }
+    param_type param() const { return P; }
     TRNG_CUDA_ENABLE
-    void param(const param_type &p_new) { p = p_new; }
+    void param(const param_type &P_new) { P = P_new; }
     TRNG_CUDA_ENABLE
-    result_type theta() const { return p.theta(); }
+    result_type theta() const { return P.theta(); }
     TRNG_CUDA_ENABLE
-    void theta(result_type theta_new) { p.theta(theta_new); }
+    void theta(result_type theta_new) { P.theta(theta_new); }
     TRNG_CUDA_ENABLE
-    result_type beta() const { return p.beta(); }
+    result_type beta() const { return P.beta(); }
     TRNG_CUDA_ENABLE
-    void beta(result_type beta_new) { p.beta(beta_new); }
+    void beta(result_type beta_new) { P.beta(beta_new); }
     // probability density function
     TRNG_CUDA_ENABLE
     result_type pdf(result_type x) const {
       if (x < 0)
         return 0;
-      x /= p.theta();
+      x /= P.theta();
       if (x > 0) {
-        const result_type t1(math::pow(x, p.beta()));
-        const result_type t2(t1 / x);
-        return p.beta() / p.theta() * t2 * math::exp(-t1);
+        const result_type t1{math::pow(x, P.beta())};
+        const result_type t2{t1 / x};
+        return P.beta() / P.theta() * t2 * math::exp(-t1);
       }
       // x==0
-      if (p.beta() == 1)
-        return 1 / p.theta();
-      if (p.beta() > 1)
+      if (P.beta() == 1)
+        return 1 / P.theta();
+      if (P.beta() > 1)
         return 0;
       return math::numeric_limits<result_type>::quiet_NaN();
     }
     // cumulative density function
     TRNG_CUDA_ENABLE
     result_type cdf(result_type x) const {
-      x /= p.theta();
+      x /= P.theta();
       if (x <= 0)
         return 0;
-      return -math::expm1(-math::pow(x, p.beta()));
+      return -math::expm1(-math::pow(x, P.beta()));
     }
     // inverse cumulative density function
     TRNG_CUDA_ENABLE
@@ -174,7 +173,7 @@ namespace trng {
 #endif
         return math::numeric_limits<result_type>::quiet_NaN();
       }
-      return p.theta() * math::pow(-math::ln1p(-x), 1 / p.beta());
+      return P.theta() * math::pow(-math::ln1p(-x), 1 / P.beta());
     }
   };
 
@@ -183,16 +182,16 @@ namespace trng {
   // EqualityComparable concept
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator==(
-      const typename weibull_dist<float_t>::param_type &p1,
-      const typename weibull_dist<float_t>::param_type &p2) {
-    return p1.theta() == p2.theta() and p1.beta() == p2.beta();
+      const typename weibull_dist<float_t>::param_type &P1,
+      const typename weibull_dist<float_t>::param_type &P2) {
+    return P1.theta() == P2.theta() and P1.beta() == P2.beta();
   }
 
   template<typename float_t>
   TRNG_CUDA_ENABLE inline bool operator!=(
-      const typename weibull_dist<float_t>::param_type &p1,
-      const typename weibull_dist<float_t>::param_type &p2) {
-    return not(p1 == p2);
+      const typename weibull_dist<float_t>::param_type &P1,
+      const typename weibull_dist<float_t>::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // -------------------------------------------------------------------
@@ -224,12 +223,12 @@ namespace trng {
   template<typename char_t, typename traits_t, typename float_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    weibull_dist<float_t> &g) {
-    typename weibull_dist<float_t>::param_type p;
+    typename weibull_dist<float_t>::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[weibull ") >> p >> utility::delim(']');
+    in >> utility::ignore_spaces() >> utility::delim("[weibull ") >> P >> utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/include/trng/yarn2.hpp
+++ b/inst/include/trng/yarn2.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,118 +34,40 @@
 
 #define TRNG_YARN2_HPP
 
-#include <ostream>
-#include <istream>
-#include <stdexcept>
 #include <trng/cuda.hpp>
 #include <trng/utility.hpp>
 #include <trng/int_types.hpp>
 #include <trng/int_math.hpp>
+#include <trng/mrg_parameter.hpp>
+#include <trng/mrg_status.hpp>
+#include <ostream>
+#include <istream>
+#include <stdexcept>
 #include <ciso646>
 
 namespace trng {
 
-  class yarn2;
-
   class yarn2 {
   public:
     // Uniform random number generator concept
-    typedef int32_t result_type;
+    using result_type = int32_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type modulus = 2147483647;
-    static const result_type gen = 123567893;
-    static const result_type min_ = 0;
-    static const result_type max_ = modulus - 1;
+    static constexpr result_type modulus = 2147483647;
+    static constexpr result_type gen = 123567893;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = modulus - 1;
+    static const int_math::power<yarn2::modulus, yarn2::gen> g;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
-    class parameter_type {
-      result_type a1, a2;
-      static int_math::power<yarn2::modulus, yarn2::gen> g;
-
-    public:
-      parameter_type() : a1(0), a2(0){};
-      parameter_type(result_type a1, result_type a2) : a1(a1), a2(a2){};
-
-      friend class yarn2;
-
-      // Equality comparable concept
-      friend bool operator==(const parameter_type &, const parameter_type &);
-      friend bool operator!=(const parameter_type &, const parameter_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const parameter_type &P) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << P.a1 << ' ' << P.a2 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, parameter_type &P) {
-        parameter_type P_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> P_new.a1 >> utility::delim(' ') >> P_new.a2 >>
-            utility::delim(')');
-        if (in)
-          P = P_new;
-        in.flags(flags);
-        return in;
-      }
-    };
-
-    class status_type {
-      result_type r1, r2;
-
-    public:
-      status_type() : r1(0), r2(1){};
-      status_type(result_type r1, result_type r2) : r1(r1), r2(r2){};
-
-      friend class yarn2;
-
-      // Equality comparable concept
-      friend bool operator==(const status_type &, const status_type &);
-      friend bool operator!=(const status_type &, const status_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const status_type &S) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << S.r1 << ' ' << S.r2 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, status_type &S) {
-        status_type S_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> S_new.r1 >> utility::delim(' ') >> S_new.r2 >>
-            utility::delim(')');
-        if (in)
-          S = S_new;
-        in.flags(flags);
-        return in;
-      }
-    };
+    using parameter_type = mrg_parameter<result_type, 2, yarn2>;
+    using status_type = mrg_status<result_type, 2, yarn2>;
 
     static const parameter_type LEcuyer1;
     static const parameter_type LEcuyer2;
@@ -154,7 +76,7 @@ namespace trng {
     explicit yarn2(parameter_type = LEcuyer1);
     explicit yarn2(unsigned long, parameter_type = LEcuyer1);
     template<typename gen>
-    explicit yarn2(gen &g, parameter_type P = LEcuyer1) : P(P), S() {
+    explicit yarn2(gen &g, parameter_type P = LEcuyer1) : P{P} {
       seed(g);
     }
 
@@ -162,10 +84,10 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      result_type r1 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r2 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      S.r1 = r1;
-      S.r2 = r2;
+      const result_type r1{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r2{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      S.r[0] = r1;
+      S.r[1] = r2;
     }
     void seed(result_type, result_type);
 
@@ -232,19 +154,19 @@ namespace trng {
 
   TRNG_CUDA_ENABLE
   inline void yarn2::step() {
-    uint64_t t(static_cast<uint64_t>(P.a1) * static_cast<uint64_t>(S.r1) +
-               static_cast<uint64_t>(P.a2) * static_cast<uint64_t>(S.r2));
-    S.r2 = S.r1;
-    S.r1 = int_math::modulo<modulus, 2>(t);
+    const uint64_t t{static_cast<uint64_t>(P.a[0]) * static_cast<uint64_t>(S.r[0]) +
+                     static_cast<uint64_t>(P.a[1]) * static_cast<uint64_t>(S.r[1])};
+    S.r[1] = S.r[0];
+    S.r[0] = int_math::modulo<modulus, 2>(t);
   }
 
   TRNG_CUDA_ENABLE
   inline yarn2::result_type yarn2::operator()() {
     step();
 #if defined __CUDA_ARCH__
-    if (S.r1 == 0)
+    if (S.r[0] == 0)
       return 0;
-    yarn2::result_type n = S.r1;
+    yarn2::result_type n = S.r[0];
     int64_t p(1), t(gen);
     while (n > 0) {
       if ((n & 0x1) == 0x1)
@@ -254,7 +176,7 @@ namespace trng {
     }
     return static_cast<yarn2::result_type>(p);
 #else
-    return (S.r1 == 0) ? 0 : P.g(S.r1);
+    return S.r[0] == 0 ? 0 : g(S.r[0]);
 #endif
   }
 
@@ -272,13 +194,13 @@ namespace trng {
 #endif
     if (s > 1) {
       jump(n + 1);
-      int32_t q0 = S.r1;
+      const int32_t q0{S.r[0]};
       jump(s);
-      int32_t q1 = S.r1;
+      const int32_t q1{S.r[0]};
       jump(s);
-      int32_t q2 = S.r1;
+      const int32_t q2{S.r[0]};
       jump(s);
-      int32_t q3 = S.r1;
+      const int32_t q3{S.r[0]};
       int32_t a[2], b[4];
       a[0] = q2;
       b[0] = q1;
@@ -287,82 +209,81 @@ namespace trng {
       b[2] = q2;
       b[3] = q1;
       int_math::gauss<2>(b, a, modulus);
-      P.a1 = a[0];
-      P.a2 = a[1];
-      S.r1 = q1;
-      S.r2 = q0;
-      for (int i = 0; i < 2; ++i)
+      P.a[0] = a[0];
+      P.a[1] = a[1];
+      S.r[0] = q1;
+      S.r[1] = q0;
+      for (int i{0}; i < 2; ++i)
         backward();
     }
   }
 
   TRNG_CUDA_ENABLE
   inline void yarn2::jump2(unsigned int s) {
-    int32_t b[4], c[4], d[2], r[2];
-    int32_t t1(P.a1), t2(P.a2);
-    b[0] = P.a1;
-    b[1] = P.a2;
+    result_type b[4], c[4]{};
+    b[0] = P.a[0];
+    b[1] = P.a[1];
     b[2] = 1;
     b[3] = 0;
-    for (unsigned int i(0); i < s; ++i)
-      if ((i & 1) == 0)
-        int_math::matrix_mult<2>(b, b, c, modulus);
-      else
-        int_math::matrix_mult<2>(c, c, b, modulus);
-    r[0] = S.r1;
-    r[1] = S.r2;
-    if ((s & 1) == 0)
+    for (unsigned int i{0}; i < s; ++i) {
+      int_math::matrix_mult<2>(b, b, c, modulus);
+      ++i;
+      if (not(i < s))
+        break;
+      int_math::matrix_mult<2>(c, c, b, modulus);
+    }
+    const result_type r[2]{S.r[0], S.r[1]};
+    result_type d[2];
+    if ((s & 1u) == 0)
       int_math::matrix_vec_mult<2>(b, r, d, modulus);
     else
       int_math::matrix_vec_mult<2>(c, r, d, modulus);
-    S.r1 = d[0];
-    S.r2 = d[1];
-    P.a1 = t1;
-    P.a2 = t2;
+    S.r[0] = d[0];
+    S.r[1] = d[1];
   }
 
   TRNG_CUDA_ENABLE
   inline void yarn2::jump(unsigned long long s) {
     if (s < 16) {
-      for (unsigned int i(0); i < s; ++i)
+      for (unsigned int i{0}; i < s; ++i)
         step();
     } else {
-      unsigned int i(0);
+      unsigned int i{0};
       while (s > 0) {
         if (s % 2 == 1)
           jump2(i);
         ++i;
-        s >>= 1;
+        s >>= 1u;
       }
     }
   }
 
   TRNG_CUDA_ENABLE
-  inline void yarn2::discard(unsigned long long n) { return jump(n); }
+  inline void yarn2::discard(unsigned long long n) { jump(n); }
 
   TRNG_CUDA_ENABLE
   inline void yarn2::backward() {
     result_type t;
-    if (P.a2 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    if (P.a[1] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a2, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[1], modulus))) %
           modulus);
-    } else if (P.a1 != 0) {
-      t = S.r2;
+    } else if (P.a[0] != 0) {
+      t = S.r[1];
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a1, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[0], modulus))) %
           modulus);
     } else
       t = 0;
-    S.r1 = S.r2;
-    S.r2 = t;
+    S.r[0] = S.r[1];
+    S.r[1] = t;
   }
 
 }  // namespace trng

--- a/inst/include/trng/yarn3.hpp
+++ b/inst/include/trng/yarn3.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,118 +34,40 @@
 
 #define TRNG_YARN3_HPP
 
-#include <ostream>
-#include <istream>
-#include <stdexcept>
 #include <trng/cuda.hpp>
 #include <trng/utility.hpp>
 #include <trng/int_types.hpp>
 #include <trng/int_math.hpp>
+#include <trng/mrg_parameter.hpp>
+#include <trng/mrg_status.hpp>
+#include <ostream>
+#include <istream>
+#include <stdexcept>
 #include <ciso646>
 
 namespace trng {
 
-  class yarn3;
-
   class yarn3 {
   public:
     // Uniform random number generator concept
-    typedef int32_t result_type;
+    using result_type = int32_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type modulus = 2147483647;
-    static const result_type gen = 123567893;
-    static const result_type min_ = 0;
-    static const result_type max_ = modulus - 1;
+    static constexpr result_type modulus = 2147483647;
+    static constexpr result_type gen = 123567893;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = modulus - 1;
+    static const int_math::power<yarn3::modulus, yarn3::gen> g;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
-    class parameter_type {
-      result_type a1, a2, a3;
-      static int_math::power<yarn3::modulus, yarn3::gen> g;
-
-    public:
-      parameter_type() : a1(0), a2(0), a3(0){};
-      parameter_type(result_type a1, result_type a2, result_type a3) : a1(a1), a2(a2), a3(a3){};
-
-      friend class yarn3;
-
-      // Equality comparable concept
-      friend bool operator==(const parameter_type &, const parameter_type &);
-      friend bool operator!=(const parameter_type &, const parameter_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const parameter_type &P) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << P.a1 << ' ' << P.a2 << ' ' << P.a3 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, parameter_type &P) {
-        parameter_type P_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> P_new.a1 >> utility::delim(' ') >> P_new.a2 >>
-            utility::delim(' ') >> P_new.a3 >> utility::delim(')');
-        if (in)
-          P = P_new;
-        in.flags(flags);
-        return in;
-      }
-    };
-
-    class status_type {
-      result_type r1, r2, r3;
-
-    public:
-      status_type() : r1(0), r2(1), r3(1){};
-      status_type(result_type r1, result_type r2, result_type r3) : r1(r1), r2(r2), r3(r3){};
-
-      friend class yarn3;
-
-      // Equality comparable concept
-      friend bool operator==(const status_type &, const status_type &);
-      friend bool operator!=(const status_type &, const status_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const status_type &S) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << S.r1 << ' ' << S.r2 << ' ' << S.r3 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, status_type &S) {
-        status_type S_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> S_new.r1 >> utility::delim(' ') >> S_new.r2 >>
-            utility::delim(' ') >> S_new.r3 >> utility::delim(')');
-        if (in)
-          S = S_new;
-        in.flags(flags);
-        return in;
-      }
-    };
+    using parameter_type = mrg_parameter<result_type, 3, yarn3>;
+    using status_type = mrg_status<result_type, 3, yarn3>;
 
     static const parameter_type LEcuyer1;
     static const parameter_type LEcuyer2;
@@ -155,7 +77,7 @@ namespace trng {
     explicit yarn3(parameter_type = LEcuyer1);
     explicit yarn3(unsigned long, parameter_type = LEcuyer1);
     template<typename gen>
-    explicit yarn3(gen &g, parameter_type P = LEcuyer1) : P(P), S() {
+    explicit yarn3(gen &g, parameter_type P = LEcuyer1) : P{P} {
       seed(g);
     }
 
@@ -163,12 +85,12 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      result_type r1 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r2 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r3 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      S.r1 = r1;
-      S.r2 = r2;
-      S.r3 = r3;
+      const result_type r1{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r2{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r3{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      S.r[0] = r1;
+      S.r[1] = r2;
+      S.r[2] = r3;
     }
     void seed(result_type, result_type, result_type);
 
@@ -235,21 +157,21 @@ namespace trng {
 
   TRNG_CUDA_ENABLE
   inline void yarn3::step() {
-    uint64_t t(static_cast<uint64_t>(P.a1) * static_cast<uint64_t>(S.r1) +
-               static_cast<uint64_t>(P.a2) * static_cast<uint64_t>(S.r2) +
-               static_cast<uint64_t>(P.a3) * static_cast<uint64_t>(S.r3));
-    S.r3 = S.r2;
-    S.r2 = S.r1;
-    S.r1 = int_math::modulo<modulus, 3>(t);
+    const uint64_t t{static_cast<uint64_t>(P.a[0]) * static_cast<uint64_t>(S.r[0]) +
+                     static_cast<uint64_t>(P.a[1]) * static_cast<uint64_t>(S.r[1]) +
+                     static_cast<uint64_t>(P.a[2]) * static_cast<uint64_t>(S.r[2])};
+    S.r[2] = S.r[1];
+    S.r[1] = S.r[0];
+    S.r[0] = int_math::modulo<modulus, 3>(t);
   }
 
   TRNG_CUDA_ENABLE
   inline yarn3::result_type yarn3::operator()() {
     step();
 #if defined __CUDA_ARCH__
-    if (S.r1 == 0)
+    if (S.r[0] == 0)
       return 0;
-    yarn3::result_type n = S.r1;
+    yarn3::result_type n = S.r[0];
     int64_t p(1ll), t(gen);
     while (n > 0) {
       if ((n & 0x1) == 0x1)
@@ -259,7 +181,7 @@ namespace trng {
     }
     return static_cast<yarn3::result_type>(p);
 #else
-    return (S.r1 == 0) ? 0 : P.g(S.r1);
+    return S.r[0] == 0 ? 0 : g(S.r[0]);
 #endif
   }
 
@@ -277,17 +199,17 @@ namespace trng {
 #endif
     if (s > 1) {
       jump(n + 1);
-      int32_t q0 = S.r1;
+      const int32_t q0{S.r[0]};
       jump(s);
-      int32_t q1 = S.r1;
+      const int32_t q1{S.r[0]};
       jump(s);
-      int32_t q2 = S.r1;
+      const int32_t q2{S.r[0]};
       jump(s);
-      int32_t q3 = S.r1;
+      const int32_t q3{S.r[0]};
       jump(s);
-      int32_t q4 = S.r1;
+      const int32_t q4{S.r[0]};
       jump(s);
-      int32_t q5 = S.r1;
+      const int32_t q5{S.r[0]};
       int32_t a[3], b[9];
       a[0] = q3;
       b[0] = q2;
@@ -302,107 +224,104 @@ namespace trng {
       b[7] = q3;
       b[8] = q2;
       int_math::gauss<3>(b, a, modulus);
-      P.a1 = a[0];
-      P.a2 = a[1];
-      P.a3 = a[2];
-      S.r1 = q2;
-      S.r2 = q1;
-      S.r3 = q0;
-      for (int i = 0; i < 3; ++i)
+      P.a[0] = a[0];
+      P.a[1] = a[1];
+      P.a[2] = a[2];
+      S.r[0] = q2;
+      S.r[1] = q1;
+      S.r[2] = q0;
+      for (int i{0}; i < 3; ++i)
         backward();
     }
   }
 
   TRNG_CUDA_ENABLE
   inline void yarn3::jump2(unsigned int s) {
-    int32_t b[9], c[9], d[3], r[3];
-    int32_t t1(P.a1), t2(P.a2), t3(P.a3);
-    b[0] = P.a1;
-    b[1] = P.a2;
-    b[2] = P.a3;
+    result_type b[9], c[9]{};
+    b[0] = P.a[0];
+    b[1] = P.a[1];
+    b[2] = P.a[2];
     b[3] = 1;
     b[4] = 0;
     b[5] = 0;
     b[6] = 0;
     b[7] = 1;
     b[8] = 0;
-    for (unsigned int i(0); i < s; ++i)
-      if ((i & 1) == 0)
-        int_math::matrix_mult<3>(b, b, c, modulus);
-      else
-        int_math::matrix_mult<3>(c, c, b, modulus);
-    r[0] = S.r1;
-    r[1] = S.r2;
-    r[2] = S.r3;
-    if ((s & 1) == 0)
+    for (unsigned int i{0}; i < s; ++i) {
+      int_math::matrix_mult<3>(b, b, c, modulus);
+      ++i;
+      if (not(i < s))
+        break;
+      int_math::matrix_mult<3>(c, c, b, modulus);
+    }
+    const result_type r[3]{S.r[0], S.r[1], S.r[2]};
+    result_type d[3];
+    if ((s & 1u) == 0)
       int_math::matrix_vec_mult<3>(b, r, d, modulus);
     else
       int_math::matrix_vec_mult<3>(c, r, d, modulus);
-    S.r1 = d[0];
-    S.r2 = d[1];
-    S.r3 = d[2];
-    P.a1 = t1;
-    P.a2 = t2;
-    P.a3 = t3;
+    S.r[0] = d[0];
+    S.r[1] = d[1];
+    S.r[2] = d[2];
   }
 
   TRNG_CUDA_ENABLE
   inline void yarn3::jump(unsigned long long s) {
     if (s < 16) {
-      for (unsigned int i(0); i < s; ++i)
+      for (unsigned int i{0}; i < s; ++i)
         step();
     } else {
-      unsigned int i(0);
+      unsigned int i{0};
       while (s > 0) {
         if (s % 2 == 1)
           jump2(i);
         ++i;
-        s >>= 1;
+        s >>= 1u;
       }
     }
   }
 
   TRNG_CUDA_ENABLE
-  inline void yarn3::discard(unsigned long long n) { return jump(n); }
+  inline void yarn3::discard(unsigned long long n) { jump(n); }
 
   TRNG_CUDA_ENABLE
   inline void yarn3::backward() {
     result_type t;
-    if (P.a3 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    if (P.a[2] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a3, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[2], modulus))) %
           modulus);
-    } else if (P.a2 != 0) {
-      t = S.r2;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+    } else if (P.a[1] != 0) {
+      t = S.r[1];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a2, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[1], modulus))) %
           modulus);
-    } else if (P.a1 != 0) {
-      t = S.r3;
+    } else if (P.a[0] != 0) {
+      t = S.r[2];
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a1, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[0], modulus))) %
           modulus);
     } else
       t = 0;
-    S.r1 = S.r2;
-    S.r2 = S.r3;
-    S.r3 = t;
+    S.r[0] = S.r[1];
+    S.r[1] = S.r[2];
+    S.r[2] = t;
   }
 
 }  // namespace trng

--- a/inst/include/trng/yarn3s.hpp
+++ b/inst/include/trng/yarn3s.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,118 +34,40 @@
 
 #define TRNG_YARN3S_HPP
 
-#include <ostream>
-#include <istream>
-#include <stdexcept>
 #include <trng/cuda.hpp>
 #include <trng/utility.hpp>
 #include <trng/int_types.hpp>
 #include <trng/int_math.hpp>
+#include <trng/mrg_parameter.hpp>
+#include <trng/mrg_status.hpp>
+#include <ostream>
+#include <istream>
+#include <stdexcept>
 #include <ciso646>
 
 namespace trng {
 
-  class yarn3s;
-
   class yarn3s {
   public:
     // Uniform random number generator concept
-    typedef int32_t result_type;
+    using result_type = int32_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type modulus = 2147462579;  // 2^31-21069
-    static const result_type gen = 1616076847;
-    static const result_type min_ = 0;
-    static const result_type max_ = modulus - 1;
+    static constexpr result_type modulus = 2147462579;  // 2^31-21069
+    static constexpr result_type gen = 1616076847;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = modulus - 1;
+    static const int_math::power<yarn3s::modulus, yarn3s::gen> g;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
-    class parameter_type {
-      result_type a1, a2, a3;
-      static int_math::power<yarn3s::modulus, yarn3s::gen> g;
-
-    public:
-      parameter_type() : a1(0), a2(0), a3(0){};
-      parameter_type(result_type a1, result_type a2, result_type a3) : a1(a1), a2(a2), a3(a3){};
-
-      friend class yarn3s;
-
-      // Equality comparable concept
-      friend bool operator==(const parameter_type &, const parameter_type &);
-      friend bool operator!=(const parameter_type &, const parameter_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const parameter_type &P) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << P.a1 << ' ' << P.a2 << ' ' << P.a3 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, parameter_type &P) {
-        parameter_type P_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> P_new.a1 >> utility::delim(' ') >> P_new.a2 >>
-            utility::delim(' ') >> P_new.a3 >> utility::delim(')');
-        if (in)
-          P = P_new;
-        in.flags(flags);
-        return in;
-      }
-    };
-
-    class status_type {
-      result_type r1, r2, r3;
-
-    public:
-      status_type() : r1(0), r2(1), r3(1){};
-      status_type(result_type r1, result_type r2, result_type r3) : r1(r1), r2(r2), r3(r3){};
-
-      friend class yarn3s;
-
-      // Equality comparable concept
-      friend bool operator==(const status_type &, const status_type &);
-      friend bool operator!=(const status_type &, const status_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const status_type &S) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << S.r1 << ' ' << S.r2 << ' ' << S.r3 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, status_type &S) {
-        status_type S_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> S_new.r1 >> utility::delim(' ') >> S_new.r2 >>
-            utility::delim(' ') >> S_new.r3 >> utility::delim(')');
-        if (in)
-          S = S_new;
-        in.flags(flags);
-        return in;
-      }
-    };
+    using parameter_type = mrg_parameter<result_type, 3, yarn3s>;
+    using status_type = mrg_status<result_type, 3, yarn3s>;
 
     static const parameter_type trng0;
     static const parameter_type trng1;
@@ -154,7 +76,7 @@ namespace trng {
     explicit yarn3s(parameter_type = trng0);
     explicit yarn3s(unsigned long, parameter_type = trng0);
     template<typename gen>
-    explicit yarn3s(gen &g, parameter_type P = trng0) : P(P), S() {
+    explicit yarn3s(gen &g, parameter_type P = trng0) : P{P} {
       seed(g);
     }
 
@@ -162,12 +84,12 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      result_type r1 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r2 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r3 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      S.r1 = r1;
-      S.r2 = r2;
-      S.r3 = r3;
+      const result_type r1{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r2{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r3{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      S.r[0] = r1;
+      S.r[1] = r2;
+      S.r[2] = r3;
     }
     void seed(result_type, result_type, result_type);
 
@@ -234,21 +156,21 @@ namespace trng {
 
   TRNG_CUDA_ENABLE
   inline void yarn3s::step() {
-    uint64_t t(static_cast<uint64_t>(P.a1) * static_cast<uint64_t>(S.r1) +
-               static_cast<uint64_t>(P.a2) * static_cast<uint64_t>(S.r2) +
-               static_cast<uint64_t>(P.a3) * static_cast<uint64_t>(S.r3));
-    S.r3 = S.r2;
-    S.r2 = S.r1;
-    S.r1 = int_math::modulo<modulus, 3>(t);
+    const uint64_t t{static_cast<uint64_t>(P.a[0]) * static_cast<uint64_t>(S.r[0]) +
+                     static_cast<uint64_t>(P.a[1]) * static_cast<uint64_t>(S.r[1]) +
+                     static_cast<uint64_t>(P.a[2]) * static_cast<uint64_t>(S.r[2])};
+    S.r[2] = S.r[1];
+    S.r[1] = S.r[0];
+    S.r[0] = int_math::modulo<modulus, 3>(t);
   }
 
   TRNG_CUDA_ENABLE
   inline yarn3s::result_type yarn3s::operator()() {
     step();
 #if defined __CUDA_ARCH__
-    if (S.r1 == 0)
+    if (S.r[0] == 0)
       return 0;
-    yarn3s::result_type n = S.r1;
+    yarn3s::result_type n = S.r[0];
     int64_t p(1), t(gen);
     while (n > 0) {
       if ((n & 0x1) == 0x1)
@@ -258,7 +180,7 @@ namespace trng {
     }
     return static_cast<yarn3s::result_type>(p);
 #else
-    return (S.r1 == 0) ? 0 : P.g(S.r1);
+    return S.r[0] == 0 ? 0 : g(S.r[0]);
 #endif
   }
 
@@ -276,17 +198,17 @@ namespace trng {
 #endif
     if (s > 1) {
       jump(n + 1);
-      int32_t q0 = S.r1;
+      const int32_t q0{S.r[0]};
       jump(s);
-      int32_t q1 = S.r1;
+      const int32_t q1{S.r[0]};
       jump(s);
-      int32_t q2 = S.r1;
+      const int32_t q2{S.r[0]};
       jump(s);
-      int32_t q3 = S.r1;
+      const int32_t q3{S.r[0]};
       jump(s);
-      int32_t q4 = S.r1;
+      const int32_t q4{S.r[0]};
       jump(s);
-      int32_t q5 = S.r1;
+      const int32_t q5{S.r[0]};
       int32_t a[3], b[9];
       a[0] = q3;
       b[0] = q2;
@@ -301,54 +223,51 @@ namespace trng {
       b[7] = q3;
       b[8] = q2;
       int_math::gauss<3>(b, a, modulus);
-      P.a1 = a[0];
-      P.a2 = a[1];
-      P.a3 = a[2];
-      S.r1 = q2;
-      S.r2 = q1;
-      S.r3 = q0;
-      for (int i = 0; i < 3; ++i)
+      P.a[0] = a[0];
+      P.a[1] = a[1];
+      P.a[2] = a[2];
+      S.r[0] = q2;
+      S.r[1] = q1;
+      S.r[2] = q0;
+      for (int i{0}; i < 3; ++i)
         backward();
     }
   }
 
   TRNG_CUDA_ENABLE
   inline void yarn3s::jump2(unsigned int s) {
-    int32_t b[9], c[9], d[3], r[3];
-    int32_t t1(P.a1), t2(P.a2), t3(P.a3);
-    b[0] = P.a1;
-    b[1] = P.a2;
-    b[2] = P.a3;
+    result_type b[9], c[9]{};
+    b[0] = P.a[0];
+    b[1] = P.a[1];
+    b[2] = P.a[2];
     b[3] = 1;
     b[4] = 0;
     b[5] = 0;
     b[6] = 0;
     b[7] = 1;
     b[8] = 0;
-    for (unsigned int i(0); i < s; ++i)
-      if ((i & 1) == 0)
-        int_math::matrix_mult<3>(b, b, c, modulus);
-      else
-        int_math::matrix_mult<3>(c, c, b, modulus);
-    r[0] = S.r1;
-    r[1] = S.r2;
-    r[2] = S.r3;
-    if ((s & 1) == 0)
+    for (unsigned int i{0}; i < s; ++i) {
+      int_math::matrix_mult<3>(b, b, c, modulus);
+      ++i;
+      if (not(i < s))
+        break;
+      int_math::matrix_mult<3>(c, c, b, modulus);
+    }
+    const result_type r[3]{S.r[0], S.r[1], S.r[2]};
+    result_type d[3];
+    if ((s & 1u) == 0)
       int_math::matrix_vec_mult<3>(b, r, d, modulus);
     else
       int_math::matrix_vec_mult<3>(c, r, d, modulus);
-    S.r1 = d[0];
-    S.r2 = d[1];
-    S.r3 = d[2];
-    P.a1 = t1;
-    P.a2 = t2;
-    P.a3 = t3;
+    S.r[0] = d[0];
+    S.r[1] = d[1];
+    S.r[2] = d[2];
   }
 
   TRNG_CUDA_ENABLE
   inline void yarn3s::jump(unsigned long long s) {
     if (s < 16) {
-      for (unsigned int i(0); i < s; ++i)
+      for (unsigned int i{0}; i < s; ++i)
         step();
     } else {
       unsigned int i(0);
@@ -356,52 +275,52 @@ namespace trng {
         if (s % 2 == 1)
           jump2(i);
         ++i;
-        s >>= 1;
+        s >>= 1u;
       }
     }
   }
 
   TRNG_CUDA_ENABLE
-  inline void yarn3s::discard(unsigned long long n) { return jump(n); }
+  inline void yarn3s::discard(unsigned long long n) { jump(n); }
 
   TRNG_CUDA_ENABLE
   inline void yarn3s::backward() {
     result_type t;
-    if (P.a3 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    if (P.a[2] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a3, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[2], modulus))) %
           modulus);
-    } else if (P.a2 != 0) {
-      t = S.r2;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+    } else if (P.a[1] != 0) {
+      t = S.r[1];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a2, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[1], modulus))) %
           modulus);
-    } else if (P.a1 != 0) {
-      t = S.r3;
+    } else if (P.a[0] != 0) {
+      t = S.r[2];
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a1, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[0], modulus))) %
           modulus);
     } else
       t = 0;
-    S.r1 = S.r2;
-    S.r2 = S.r3;
-    S.r3 = t;
+    S.r[0] = S.r[1];
+    S.r[1] = S.r[2];
+    S.r[2] = t;
   }
 
 }  // namespace trng

--- a/inst/include/trng/yarn4.hpp
+++ b/inst/include/trng/yarn4.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,122 +34,40 @@
 
 #define TRNG_YARN4_HPP
 
-#include <ostream>
-#include <istream>
-#include <stdexcept>
 #include <trng/cuda.hpp>
 #include <trng/utility.hpp>
 #include <trng/int_types.hpp>
 #include <trng/int_math.hpp>
+#include <trng/mrg_parameter.hpp>
+#include <trng/mrg_status.hpp>
+#include <ostream>
+#include <istream>
+#include <stdexcept>
 #include <ciso646>
 
 namespace trng {
 
-  class yarn4;
-
   class yarn4 {
   public:
     // Uniform random number generator concept
-    typedef int32_t result_type;
+    using result_type = int32_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type modulus = 2147483647;
-    static const result_type gen = 123567893;
-    static const result_type min_ = 0;
-    static const result_type max_ = modulus - 1;
+    static constexpr result_type modulus = 2147483647;
+    static constexpr result_type gen = 123567893;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = modulus - 1;
+    static const int_math::power<yarn4::modulus, yarn4::gen> g;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
-    class parameter_type {
-      result_type a1, a2, a3, a4;
-      static int_math::power<yarn4::modulus, yarn4::gen> g;
-
-    public:
-      parameter_type() : a1(0), a2(0), a3(0), a4(0){};
-      parameter_type(result_type a1, result_type a2, result_type a3, result_type a4)
-          : a1(a1), a2(a2), a3(a3), a4(a4){};
-
-      friend class yarn4;
-
-      // Equality comparable concept
-      friend bool operator==(const parameter_type &, const parameter_type &);
-      friend bool operator!=(const parameter_type &, const parameter_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const parameter_type &P) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << P.a1 << ' ' << P.a2 << ' ' << P.a3 << ' ' << P.a4 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, parameter_type &P) {
-        parameter_type P_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> P_new.a1 >> utility::delim(' ') >> P_new.a2 >>
-            utility::delim(' ') >> P_new.a3 >> utility::delim(' ') >> P_new.a4 >>
-            utility::delim(')');
-        if (in)
-          P = P_new;
-        in.flags(flags);
-        return in;
-      }
-    };
-
-    class status_type {
-      result_type r1, r2, r3, r4;
-
-    public:
-      status_type() : r1(0), r2(1), r3(1), r4(1){};
-      status_type(result_type r1, result_type r2, result_type r3, result_type r4)
-          : r1(r1), r2(r2), r3(r3), r4(r4){};
-
-      friend class yarn4;
-
-      // Equality comparable concept
-      friend bool operator==(const status_type &, const status_type &);
-      friend bool operator!=(const status_type &, const status_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const status_type &S) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << S.r1 << ' ' << S.r2 << ' ' << S.r3 << ' ' << S.r4 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, status_type &S) {
-        status_type S_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> S_new.r1 >> utility::delim(' ') >> S_new.r2 >>
-            utility::delim(' ') >> S_new.r3 >> utility::delim(' ') >> S_new.r4 >>
-            utility::delim(')');
-        if (in)
-          S = S_new;
-        in.flags(flags);
-        return in;
-      }
-    };
+    using parameter_type = mrg_parameter<result_type, 4, yarn4>;
+    using status_type = mrg_status<result_type, 4, yarn4>;
 
     static const parameter_type LEcuyer1;
     static const parameter_type LEcuyer2;
@@ -158,7 +76,7 @@ namespace trng {
     explicit yarn4(parameter_type = LEcuyer1);
     explicit yarn4(unsigned long, parameter_type = LEcuyer1);
     template<typename gen>
-    explicit yarn4(gen &g, parameter_type P = LEcuyer1) : P(P), S() {
+    explicit yarn4(gen &g, parameter_type P = LEcuyer1) : P{P} {
       seed(g);
     }
 
@@ -166,14 +84,14 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      result_type r1 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r2 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r3 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r4 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      S.r1 = r1;
-      S.r2 = r2;
-      S.r3 = r3;
-      S.r4 = r4;
+      const result_type r1{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r2{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r3{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r4{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      S.r[0] = r1;
+      S.r[1] = r2;
+      S.r[2] = r3;
+      S.r[3] = r4;
     }
     void seed(result_type, result_type, result_type, result_type);
 
@@ -239,23 +157,23 @@ namespace trng {
 
   TRNG_CUDA_ENABLE
   inline void yarn4::step() {
-    uint64_t t(static_cast<uint64_t>(P.a1) * static_cast<uint64_t>(S.r1) +
-               static_cast<uint64_t>(P.a2) * static_cast<uint64_t>(S.r2) +
-               static_cast<uint64_t>(P.a3) * static_cast<uint64_t>(S.r3) +
-               static_cast<uint64_t>(P.a4) * static_cast<uint64_t>(S.r4));
-    S.r4 = S.r3;
-    S.r3 = S.r2;
-    S.r2 = S.r1;
-    S.r1 = int_math::modulo<modulus, 4>(t);
+    const uint64_t t{static_cast<uint64_t>(P.a[0]) * static_cast<uint64_t>(S.r[0]) +
+                     static_cast<uint64_t>(P.a[1]) * static_cast<uint64_t>(S.r[1]) +
+                     static_cast<uint64_t>(P.a[2]) * static_cast<uint64_t>(S.r[2]) +
+                     static_cast<uint64_t>(P.a[3]) * static_cast<uint64_t>(S.r[3])};
+    S.r[3] = S.r[2];
+    S.r[2] = S.r[1];
+    S.r[1] = S.r[0];
+    S.r[0] = int_math::modulo<modulus, 4>(t);
   }
 
   TRNG_CUDA_ENABLE
   inline yarn4::result_type yarn4::operator()() {
     step();
 #if defined __CUDA_ARCH__
-    if (S.r1 == 0)
+    if (S.r[0] == 0)
       return 0;
-    yarn4::result_type n = S.r1;
+    yarn4::result_type n = S.r[0];
     int64_t p(1), t(gen);
     while (n > 0) {
       if ((n & 0x1) == 0x1)
@@ -265,7 +183,7 @@ namespace trng {
     }
     return static_cast<yarn4::result_type>(p);
 #else
-    return (S.r1 == 0) ? 0 : P.g(S.r1);
+    return S.r[0] == 0 ? 0 : g(S.r[0]);
 #endif
   }
 
@@ -283,21 +201,21 @@ namespace trng {
 #endif
     if (s > 1) {
       jump(n + 1);
-      int32_t q0 = S.r1;
+      const int32_t q0{S.r[0]};
       jump(s);
-      int32_t q1 = S.r1;
+      const int32_t q1{S.r[0]};
       jump(s);
-      int32_t q2 = S.r1;
+      const int32_t q2{S.r[0]};
       jump(s);
-      int32_t q3 = S.r1;
+      const int32_t q3{S.r[0]};
       jump(s);
-      int32_t q4 = S.r1;
+      const int32_t q4{S.r[0]};
       jump(s);
-      int32_t q5 = S.r1;
+      const int32_t q5{S.r[0]};
       jump(s);
-      int32_t q6 = S.r1;
+      const int32_t q6{S.r[0]};
       jump(s);
-      int32_t q7 = S.r1;
+      const int32_t q7{S.r[0]};
       int32_t a[4], b[16];
       a[0] = q4;
       b[0] = q3;
@@ -320,27 +238,26 @@ namespace trng {
       b[14] = q4;
       b[15] = q3;
       int_math::gauss<4>(b, a, modulus);
-      P.a1 = a[0];
-      P.a2 = a[1];
-      P.a3 = a[2];
-      P.a4 = a[3];
-      S.r1 = q3;
-      S.r2 = q2;
-      S.r3 = q1;
-      S.r4 = q0;
-      for (int i = 0; i < 4; ++i)
+      P.a[0] = a[0];
+      P.a[1] = a[1];
+      P.a[2] = a[2];
+      P.a[3] = a[3];
+      S.r[0] = q3;
+      S.r[1] = q2;
+      S.r[2] = q1;
+      S.r[3] = q0;
+      for (int i{0}; i < 4; ++i)
         backward();
     }
   }
 
   TRNG_CUDA_ENABLE
   inline void yarn4::jump2(unsigned int s) {
-    int32_t b[16], c[16], d[4], r[4];
-    int32_t t1(P.a1), t2(P.a2), t3(P.a3), t4(P.a4);
-    b[0] = P.a1;
-    b[1] = P.a2;
-    b[2] = P.a3;
-    b[3] = P.a4;
+    result_type b[16], c[16]{};
+    b[0] = P.a[0];
+    b[1] = P.a[1];
+    b[2] = P.a[2];
+    b[3] = P.a[3];
     b[4] = 1;
     b[5] = 0;
     b[6] = 0;
@@ -353,36 +270,32 @@ namespace trng {
     b[13] = 0;
     b[14] = 1;
     b[15] = 0;
-    for (unsigned int i(0); i < s; ++i)
-      if ((i & 1) == 0)
-        int_math::matrix_mult<4>(b, b, c, modulus);
-      else
-        int_math::matrix_mult<4>(c, c, b, modulus);
-    r[0] = S.r1;
-    r[1] = S.r2;
-    r[2] = S.r3;
-    r[3] = S.r4;
-    if ((s & 1) == 0)
+    for (unsigned int i{0}; i < s; ++i) {
+      int_math::matrix_mult<4>(b, b, c, modulus);
+      ++i;
+      if (not(i < s))
+        break;
+      int_math::matrix_mult<4>(c, c, b, modulus);
+    }
+    const result_type r[4]{S.r[0], S.r[1], S.r[2], S.r[3]};
+    result_type d[4];
+    if ((s & 1u) == 0)
       int_math::matrix_vec_mult<4>(b, r, d, modulus);
     else
       int_math::matrix_vec_mult<4>(c, r, d, modulus);
-    S.r1 = d[0];
-    S.r2 = d[1];
-    S.r3 = d[2];
-    S.r4 = d[3];
-    P.a1 = t1;
-    P.a2 = t2;
-    P.a3 = t3;
-    P.a4 = t4;
+    S.r[0] = d[0];
+    S.r[1] = d[1];
+    S.r[2] = d[2];
+    S.r[3] = d[3];
   }
 
   TRNG_CUDA_ENABLE
   inline void yarn4::jump(unsigned long long s) {
     if (s < 16) {
-      for (unsigned int i(0); i < s; ++i)
+      for (unsigned int i{0}; i < s; ++i)
         step();
     } else {
-      unsigned int i(0);
+      unsigned int i{0};
       while (s > 0) {
         if (s % 2 == 1)
           jump2(i);
@@ -393,65 +306,65 @@ namespace trng {
   }
 
   TRNG_CUDA_ENABLE
-  inline void yarn4::discard(unsigned long long n) { return jump(n); }
+  inline void yarn4::discard(unsigned long long n) { jump(n); }
 
   TRNG_CUDA_ENABLE
   inline void yarn4::backward() {
     result_type t;
-    if (P.a4 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    if (P.a[3] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a3) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[2]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a4, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[3], modulus))) %
           modulus);
-    } else if (P.a3 != 0) {
-      t = S.r2;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+    } else if (P.a[2] != 0) {
+      t = S.r[1];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a3, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[2], modulus))) %
           modulus);
-    } else if (P.a2 != 0) {
-      t = S.r3;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+    } else if (P.a[1] != 0) {
+      t = S.r[2];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a2, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[1], modulus))) %
           modulus);
-    } else if (P.a1 != 0) {
-      t = S.r4;
+    } else if (P.a[0] != 0) {
+      t = S.r[3];
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a1, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[0], modulus))) %
           modulus);
     } else
       t = 0;
-    S.r1 = S.r2;
-    S.r2 = S.r3;
-    S.r3 = S.r4;
-    S.r4 = t;
+    S.r[0] = S.r[1];
+    S.r[1] = S.r[2];
+    S.r[2] = S.r[3];
+    S.r[3] = t;
   }
 
 }  // namespace trng

--- a/inst/include/trng/yarn5.hpp
+++ b/inst/include/trng/yarn5.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,124 +34,40 @@
 
 #define TRNG_YARN5_HPP
 
-#include <ostream>
-#include <istream>
-#include <stdexcept>
 #include <trng/cuda.hpp>
 #include <trng/utility.hpp>
 #include <trng/int_types.hpp>
 #include <trng/int_math.hpp>
+#include <trng/mrg_parameter.hpp>
+#include <trng/mrg_status.hpp>
+#include <ostream>
+#include <istream>
+#include <stdexcept>
 #include <ciso646>
 
 namespace trng {
 
-  class yarn5;
-
   class yarn5 {
   public:
     // Uniform random number generator concept
-    typedef int32_t result_type;
+    using result_type = int32_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type modulus = 2147483647;
-    static const result_type gen = 123567893;
-    static const result_type min_ = 0;
-    static const result_type max_ = modulus - 1;
+    static constexpr result_type modulus = 2147483647;
+    static constexpr result_type gen = 123567893;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = modulus - 1;
+    static const int_math::power<yarn5::modulus, yarn5::gen> g;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
-    class parameter_type {
-      result_type a1, a2, a3, a4, a5;
-      static int_math::power<yarn5::modulus, yarn5::gen> g;
-
-    public:
-      parameter_type() : a1(0), a2(0), a3(0), a4(0), a5(0){};
-      parameter_type(result_type a1, result_type a2, result_type a3, result_type a4,
-                     result_type a5)
-          : a1(a1), a2(a2), a3(a3), a4(a4), a5(a5){};
-
-      friend class yarn5;
-
-      // Equality comparable concept
-      friend bool operator==(const parameter_type &, const parameter_type &);
-      friend bool operator!=(const parameter_type &, const parameter_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const parameter_type &P) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << P.a1 << ' ' << P.a2 << ' ' << P.a3 << ' ' << P.a4 << ' ' << P.a5 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, parameter_type &P) {
-        parameter_type P_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> P_new.a1 >> utility::delim(' ') >> P_new.a2 >>
-            utility::delim(' ') >> P_new.a3 >> utility::delim(' ') >> P_new.a4 >>
-            utility::delim(' ') >> P_new.a5 >> utility::delim(')');
-        if (in)
-          P = P_new;
-        in.flags(flags);
-        return in;
-      }
-    };
-
-    class status_type {
-      result_type r1, r2, r3, r4, r5;
-
-    public:
-      status_type() : r1(0), r2(1), r3(1), r4(1), r5(1){};
-      status_type(result_type r1, result_type r2, result_type r3, result_type r4,
-                  result_type r5)
-          : r1(r1), r2(r2), r3(r3), r4(r4), r5(r5){};
-
-      friend class yarn5;
-
-      // Equality comparable concept
-      friend bool operator==(const status_type &, const status_type &);
-      friend bool operator!=(const status_type &, const status_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const status_type &S) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << S.r1 << ' ' << S.r2 << ' ' << S.r3 << ' ' << S.r4 << ' ' << S.r5 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, status_type &S) {
-        status_type S_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> S_new.r1 >> utility::delim(' ') >> S_new.r2 >>
-            utility::delim(' ') >> S_new.r3 >> utility::delim(' ') >> S_new.r4 >>
-            utility::delim(' ') >> S_new.r5 >> utility::delim(')');
-        if (in)
-          S = S_new;
-        in.flags(flags);
-        return in;
-      }
-    };
+    using parameter_type = mrg_parameter<result_type, 5, yarn5>;
+    using status_type = mrg_status<result_type, 5, yarn5>;
 
     static const parameter_type LEcuyer1;
 
@@ -159,7 +75,7 @@ namespace trng {
     explicit yarn5(const parameter_type &P = LEcuyer1);
     explicit yarn5(unsigned long, const parameter_type &P = LEcuyer1);
     template<typename gen>
-    explicit yarn5(gen &g, const parameter_type &P = LEcuyer1) : P(P), S() {
+    explicit yarn5(gen &g, const parameter_type &P = LEcuyer1) : P{P} {
       seed(g);
     }
 
@@ -167,16 +83,16 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      result_type r1 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r2 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r3 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r4 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      result_type r5 = static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus);
-      S.r1 = r1;
-      S.r2 = r2;
-      S.r3 = r3;
-      S.r4 = r4;
-      S.r5 = r5;
+      const result_type r1{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r2{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r3{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r4{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      const result_type r5{static_cast<uint32_t>(g()) % static_cast<uint32_t>(modulus)};
+      S.r[0] = r1;
+      S.r[1] = r2;
+      S.r[2] = r3;
+      S.r[3] = r4;
+      S.r[4] = r5;
     }
     void seed(result_type, result_type, result_type, result_type, result_type);
 
@@ -243,27 +159,27 @@ namespace trng {
 
   TRNG_CUDA_ENABLE
   inline void yarn5::step() {
-    uint64_t t(static_cast<uint64_t>(P.a1) * static_cast<uint64_t>(S.r1) +
-               static_cast<uint64_t>(P.a2) * static_cast<uint64_t>(S.r2) +
-               static_cast<uint64_t>(P.a3) * static_cast<uint64_t>(S.r3) +
-               static_cast<uint64_t>(P.a4) * static_cast<uint64_t>(S.r4));
+    uint64_t t{static_cast<uint64_t>(P.a[0]) * static_cast<uint64_t>(S.r[0]) +
+               static_cast<uint64_t>(P.a[1]) * static_cast<uint64_t>(S.r[1]) +
+               static_cast<uint64_t>(P.a[2]) * static_cast<uint64_t>(S.r[2]) +
+               static_cast<uint64_t>(P.a[3]) * static_cast<uint64_t>(S.r[3])};
     if (t >= static_cast<uint64_t>(2u) * modulus * modulus)
       t -= static_cast<uint64_t>(2u) * modulus * modulus;
-    t += static_cast<uint64_t>(P.a5) * static_cast<uint64_t>(S.r5);
-    S.r5 = S.r4;
-    S.r4 = S.r3;
-    S.r3 = S.r2;
-    S.r2 = S.r1;
-    S.r1 = int_math::modulo<modulus, 5>(t);
+    t += static_cast<uint64_t>(P.a[4]) * static_cast<uint64_t>(S.r[4]);
+    S.r[4] = S.r[3];
+    S.r[3] = S.r[2];
+    S.r[2] = S.r[1];
+    S.r[1] = S.r[0];
+    S.r[0] = int_math::modulo<modulus, 5>(t);
   }
 
   TRNG_CUDA_ENABLE
   inline yarn5::result_type yarn5::operator()() {
     step();
 #if defined __CUDA_ARCH__
-    if (S.r1 == 0)
+    if (S.r[0] == 0)
       return 0;
-    yarn5::result_type n = S.r1;
+    yarn5::result_type n = S.r[0];
     int64_t p(1), t(gen);
     while (n > 0) {
       if ((n & 0x1) == 0x1)
@@ -273,7 +189,7 @@ namespace trng {
     }
     return static_cast<yarn5::result_type>(p);
 #else
-    return (S.r1 == 0) ? 0 : P.g(S.r1);
+    return S.r[0] == 0 ? 0 : g(S.r[0]);
 #endif
   }
 
@@ -291,25 +207,25 @@ namespace trng {
 #endif
     if (s > 1) {
       jump(n + 1);
-      int32_t q0 = S.r1;
+      const int32_t q0{S.r[0]};
       jump(s);
-      int32_t q1 = S.r1;
+      const int32_t q1{S.r[0]};
       jump(s);
-      int32_t q2 = S.r1;
+      const int32_t q2{S.r[0]};
       jump(s);
-      int32_t q3 = S.r1;
+      const int32_t q3{S.r[0]};
       jump(s);
-      int32_t q4 = S.r1;
+      const int32_t q4{S.r[0]};
       jump(s);
-      int32_t q5 = S.r1;
+      const int32_t q5{S.r[0]};
       jump(s);
-      int32_t q6 = S.r1;
+      const int32_t q6{S.r[0]};
       jump(s);
-      int32_t q7 = S.r1;
+      const int32_t q7{S.r[0]};
       jump(s);
-      int32_t q8 = S.r1;
+      const int32_t q8{S.r[0]};
       jump(s);
-      int32_t q9 = S.r1;
+      const int32_t q9{S.r[0]};
       int32_t a[5], b[25];
       a[0] = q5;
       b[0] = q4;
@@ -342,30 +258,29 @@ namespace trng {
       b[23] = q5;
       b[24] = q4;
       int_math::gauss<5>(b, a, modulus);
-      P.a1 = a[0];
-      P.a2 = a[1];
-      P.a3 = a[2];
-      P.a4 = a[3];
-      P.a5 = a[4];
-      S.r1 = q4;
-      S.r2 = q3;
-      S.r3 = q2;
-      S.r4 = q1;
-      S.r5 = q0;
-      for (int i = 0; i < 5; ++i)
+      P.a[0] = a[0];
+      P.a[1] = a[1];
+      P.a[2] = a[2];
+      P.a[3] = a[3];
+      P.a[4] = a[4];
+      S.r[0] = q4;
+      S.r[1] = q3;
+      S.r[2] = q2;
+      S.r[3] = q1;
+      S.r[4] = q0;
+      for (int i{0}; i < 5; ++i)
         backward();
     }
   }
 
   TRNG_CUDA_ENABLE
   inline void yarn5::jump2(unsigned int s) {
-    int32_t b[25], c[25], d[5], r[5];
-    int32_t t1(P.a1), t2(P.a2), t3(P.a3), t4(P.a4), t5(P.a5);
-    b[0] = P.a1;
-    b[1] = P.a2;
-    b[2] = P.a3;
-    b[3] = P.a4;
-    b[4] = P.a5;
+    result_type b[25], c[25]{};
+    b[0] = P.a[0];
+    b[1] = P.a[1];
+    b[2] = P.a[2];
+    b[3] = P.a[3];
+    b[4] = P.a[4];
     b[5] = 1;
     b[6] = 0;
     b[7] = 0;
@@ -386,30 +301,24 @@ namespace trng {
     b[22] = 0;
     b[23] = 1;
     b[24] = 0;
-    for (unsigned int i(0); i < s; ++i)
-      if ((i & 1) == 0)
-        int_math::matrix_mult<5>(b, b, c, modulus);
-      else
-        int_math::matrix_mult<5>(c, c, b, modulus);
-    r[0] = S.r1;
-    r[1] = S.r2;
-    r[2] = S.r3;
-    r[3] = S.r4;
-    r[4] = S.r5;
-    if ((s & 1) == 0)
+    for (unsigned int i{0}; i < s; ++i) {
+      int_math::matrix_mult<5>(b, b, c, modulus);
+      ++i;
+      if (not(i < s))
+        break;
+      int_math::matrix_mult<5>(c, c, b, modulus);
+    }
+    const result_type r[5]{S.r[0], S.r[1], S.r[2], S.r[3], S.r[4]};
+    result_type d[5];
+    if ((s & 1u) == 0)
       int_math::matrix_vec_mult<5>(b, r, d, modulus);
     else
       int_math::matrix_vec_mult<5>(c, r, d, modulus);
-    S.r1 = d[0];
-    S.r2 = d[1];
-    S.r3 = d[2];
-    S.r4 = d[3];
-    S.r5 = d[4];
-    P.a1 = t1;
-    P.a2 = t2;
-    P.a3 = t3;
-    P.a4 = t4;
-    P.a5 = t5;
+    S.r[0] = d[0];
+    S.r[1] = d[1];
+    S.r[2] = d[2];
+    S.r[3] = d[3];
+    S.r[4] = d[4];
   }
 
   TRNG_CUDA_ENABLE
@@ -423,94 +332,94 @@ namespace trng {
         if (s % 2 == 1)
           jump2(i);
         ++i;
-        s >>= 1;
+        s >>= 1u;
       }
     }
   }
 
   TRNG_CUDA_ENABLE
-  inline void yarn5::discard(unsigned long long n) { return jump(n); }
+  inline void yarn5::discard(unsigned long long n) { jump(n); }
 
   TRNG_CUDA_ENABLE
   inline void yarn5::backward() {
     result_type t;
-    if (P.a5 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    if (P.a[4] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a3) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[2]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a4) * static_cast<int64_t>(S.r5)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[3]) * static_cast<int64_t>(S.r[4])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a5, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[4], modulus))) %
           modulus);
-    } else if (P.a4 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    } else if (P.a[3] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a3) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[2]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a4, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[3], modulus))) %
           modulus);
-    } else if (P.a3 != 0) {
-      t = S.r2;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+    } else if (P.a[2] != 0) {
+      t = S.r[1];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a3, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[2], modulus))) %
           modulus);
-    } else if (P.a2 != 0) {
-      t = S.r3;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+    } else if (P.a[1] != 0) {
+      t = S.r[2];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a2, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[1], modulus))) %
           modulus);
-    } else if (P.a1 != 0) {
-      t = S.r4;
+    } else if (P.a[0] != 0) {
+      t = S.r[3];
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a1, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[0], modulus))) %
           modulus);
     } else
       t = 0;
-    S.r1 = S.r2;
-    S.r2 = S.r3;
-    S.r3 = S.r4;
-    S.r4 = S.r5;
-    S.r5 = t;
+    S.r[0] = S.r[1];
+    S.r[1] = S.r[2];
+    S.r[2] = S.r[3];
+    S.r[3] = S.r[4];
+    S.r[4] = t;
   }
 
 }  // namespace trng

--- a/inst/include/trng/yarn5s.hpp
+++ b/inst/include/trng/yarn5s.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,124 +34,40 @@
 
 #define TRNG_YARN5S_HPP
 
-#include <ostream>
-#include <istream>
-#include <stdexcept>
 #include <trng/cuda.hpp>
 #include <trng/utility.hpp>
 #include <trng/int_types.hpp>
 #include <trng/int_math.hpp>
+#include <trng/mrg_parameter.hpp>
+#include <trng/mrg_status.hpp>
+#include <ostream>
+#include <istream>
+#include <stdexcept>
 #include <ciso646>
 
 namespace trng {
 
-  class yarn5s;
-
   class yarn5s {
   public:
     // Uniform random number generator concept
-    typedef int32_t result_type;
+    using result_type = int32_t;
     TRNG_CUDA_ENABLE
     result_type operator()();
 
   private:
-    static const result_type modulus = 2147461007;  // 2^31 - 22641
-    static const result_type gen = 889744251;
-    static const result_type min_ = 0;
-    static const result_type max_ = modulus - 1;
+    static constexpr result_type modulus = 2147461007;  // 2^31 - 22641
+    static constexpr result_type gen = 889744251;
+    static constexpr result_type min_ = 0;
+    static constexpr result_type max_ = modulus - 1;
+    static const int_math::power<yarn5s::modulus, yarn5s::gen> g;
 
   public:
     static constexpr result_type min() { return min_; }
     static constexpr result_type max() { return max_; }
 
     // Parameter and status classes
-    class parameter_type;
-    class status_type;
-
-    class parameter_type {
-      result_type a1, a2, a3, a4, a5;
-      static int_math::power<yarn5s::modulus, yarn5s::gen> g;
-
-    public:
-      parameter_type() : a1(0), a2(0), a3(0), a4(0), a5(0){};
-      parameter_type(result_type a1, result_type a2, result_type a3, result_type a4,
-                     result_type a5)
-          : a1(a1), a2(a2), a3(a3), a4(a4), a5(a5){};
-
-      friend class yarn5s;
-
-      // Equality comparable concept
-      friend bool operator==(const parameter_type &, const parameter_type &);
-      friend bool operator!=(const parameter_type &, const parameter_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const parameter_type &P) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << P.a1 << ' ' << P.a2 << ' ' << P.a3 << ' ' << P.a4 << ' ' << P.a5 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, parameter_type &P) {
-        parameter_type P_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> P_new.a1 >> utility::delim(' ') >> P_new.a2 >>
-            utility::delim(' ') >> P_new.a3 >> utility::delim(' ') >> P_new.a4 >>
-            utility::delim(' ') >> P_new.a5 >> utility::delim(')');
-        if (in)
-          P = P_new;
-        in.flags(flags);
-        return in;
-      }
-    };
-
-    class status_type {
-      result_type r1, r2, r3, r4, r5;
-
-    public:
-      status_type() : r1(0), r2(1), r3(1), r4(1), r5(1){};
-      status_type(result_type r1, result_type r2, result_type r3, result_type r4,
-                  result_type r5)
-          : r1(r1), r2(r2), r3(r3), r4(r4), r5(r5){};
-
-      friend class yarn5s;
-
-      // Equality comparable concept
-      friend bool operator==(const status_type &, const status_type &);
-      friend bool operator!=(const status_type &, const status_type &);
-
-      // Streamable concept
-      template<typename char_t, typename traits_t>
-      friend std::basic_ostream<char_t, traits_t> &operator<<(
-          std::basic_ostream<char_t, traits_t> &out, const status_type &S) {
-        std::ios_base::fmtflags flags(out.flags());
-        out.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        out << '(' << S.r1 << ' ' << S.r2 << ' ' << S.r3 << ' ' << S.r4 << ' ' << S.r5 << ')';
-        out.flags(flags);
-        return out;
-      }
-
-      template<typename char_t, typename traits_t>
-      friend std::basic_istream<char_t, traits_t> &operator>>(
-          std::basic_istream<char_t, traits_t> &in, status_type &S) {
-        status_type S_new;
-        std::ios_base::fmtflags flags(in.flags());
-        in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-        in >> utility::delim('(') >> S_new.r1 >> utility::delim(' ') >> S_new.r2 >>
-            utility::delim(' ') >> S_new.r3 >> utility::delim(' ') >> S_new.r4 >>
-            utility::delim(' ') >> S_new.r5 >> utility::delim(')');
-        if (in)
-          S = S_new;
-        in.flags(flags);
-        return in;
-      }
-    };
+    using parameter_type = mrg_parameter<result_type, 5, yarn5s>;
+    using status_type = mrg_status<result_type, 5, yarn5s>;
 
     static const parameter_type trng0;
     static const parameter_type trng1;
@@ -160,7 +76,7 @@ namespace trng {
     explicit yarn5s(const parameter_type &P = trng0);
     explicit yarn5s(unsigned long, const parameter_type &P = trng0);
     template<typename gen>
-    explicit yarn5s(gen &g, const parameter_type &P = trng0) : P(P), S() {
+    explicit yarn5s(gen &g, const parameter_type &P = trng0) : P{P} {
       seed(g);
     }
 
@@ -168,16 +84,16 @@ namespace trng {
     void seed(unsigned long);
     template<typename gen>
     void seed(gen &g) {
-      result_type r1 = static_cast<int32_t>(g()) % static_cast<int32_t>(modulus);
-      result_type r2 = static_cast<int32_t>(g()) % static_cast<int32_t>(modulus);
-      result_type r3 = static_cast<int32_t>(g()) % static_cast<int32_t>(modulus);
-      result_type r4 = static_cast<int32_t>(g()) % static_cast<int32_t>(modulus);
-      result_type r5 = static_cast<int32_t>(g()) % static_cast<int32_t>(modulus);
-      S.r1 = r1;
-      S.r2 = r2;
-      S.r3 = r3;
-      S.r4 = r4;
-      S.r5 = r5;
+      const result_type r1{static_cast<int32_t>(g()) % static_cast<int32_t>(modulus)};
+      const result_type r2{static_cast<int32_t>(g()) % static_cast<int32_t>(modulus)};
+      const result_type r3{static_cast<int32_t>(g()) % static_cast<int32_t>(modulus)};
+      const result_type r4{static_cast<int32_t>(g()) % static_cast<int32_t>(modulus)};
+      const result_type r5{static_cast<int32_t>(g()) % static_cast<int32_t>(modulus)};
+      S.r[0] = r1;
+      S.r[1] = r2;
+      S.r[2] = r3;
+      S.r[3] = r4;
+      S.r[4] = r5;
     }
     void seed(result_type, result_type, result_type, result_type, result_type);
 
@@ -244,27 +160,27 @@ namespace trng {
 
   TRNG_CUDA_ENABLE
   inline void yarn5s::step() {
-    uint64_t t(static_cast<uint64_t>(P.a1) * static_cast<uint64_t>(S.r1) +
-               static_cast<uint64_t>(P.a2) * static_cast<uint64_t>(S.r2) +
-               static_cast<uint64_t>(P.a3) * static_cast<uint64_t>(S.r3) +
-               static_cast<uint64_t>(P.a4) * static_cast<uint64_t>(S.r4));
+    uint64_t t{static_cast<uint64_t>(P.a[0]) * static_cast<uint64_t>(S.r[0]) +
+               static_cast<uint64_t>(P.a[1]) * static_cast<uint64_t>(S.r[1]) +
+               static_cast<uint64_t>(P.a[2]) * static_cast<uint64_t>(S.r[2]) +
+               static_cast<uint64_t>(P.a[3]) * static_cast<uint64_t>(S.r[3])};
     if (t >= static_cast<uint64_t>(2u) * modulus * modulus)
       t -= static_cast<uint64_t>(2u) * modulus * modulus;
-    t += static_cast<uint64_t>(P.a5) * static_cast<uint64_t>(S.r5);
-    S.r5 = S.r4;
-    S.r4 = S.r3;
-    S.r3 = S.r2;
-    S.r2 = S.r1;
-    S.r1 = int_math::modulo<modulus, 5>(t);
+    t += static_cast<uint64_t>(P.a[4]) * static_cast<uint64_t>(S.r[4]);
+    S.r[4] = S.r[3];
+    S.r[3] = S.r[2];
+    S.r[2] = S.r[1];
+    S.r[1] = S.r[0];
+    S.r[0] = int_math::modulo<modulus, 5>(t);
   }
 
   TRNG_CUDA_ENABLE
   inline yarn5s::result_type yarn5s::operator()() {
     step();
 #if defined __CUDA_ARCH__
-    if (S.r1 == 0)
+    if (S.r[0] == 0)
       return 0;
-    yarn5s::result_type n = S.r1;
+    yarn5s::result_type n = S.r[0];
     int64_t p(1), t(gen);
     while (n > 0) {
       if ((n & 0x1) == 0x1)
@@ -274,7 +190,7 @@ namespace trng {
     }
     return static_cast<yarn5s::result_type>(p);
 #else
-    return (S.r1 == 0) ? 0 : P.g(S.r1);
+    return S.r[0] == 0 ? 0 : g(S.r[0]);
 #endif
   }
 
@@ -292,25 +208,25 @@ namespace trng {
 #endif
     if (s > 1) {
       jump(n + 1);
-      int32_t q0 = S.r1;
+      const int32_t q0{S.r[0]};
       jump(s);
-      int32_t q1 = S.r1;
+      const int32_t q1{S.r[0]};
       jump(s);
-      int32_t q2 = S.r1;
+      const int32_t q2{S.r[0]};
       jump(s);
-      int32_t q3 = S.r1;
+      const int32_t q3{S.r[0]};
       jump(s);
-      int32_t q4 = S.r1;
+      const int32_t q4{S.r[0]};
       jump(s);
-      int32_t q5 = S.r1;
+      const int32_t q5{S.r[0]};
       jump(s);
-      int32_t q6 = S.r1;
+      const int32_t q6{S.r[0]};
       jump(s);
-      int32_t q7 = S.r1;
+      const int32_t q7{S.r[0]};
       jump(s);
-      int32_t q8 = S.r1;
+      const int32_t q8{S.r[0]};
       jump(s);
-      int32_t q9 = S.r1;
+      const int32_t q9{S.r[0]};
       int32_t a[5], b[25];
       a[0] = q5;
       b[0] = q4;
@@ -343,30 +259,29 @@ namespace trng {
       b[23] = q5;
       b[24] = q4;
       int_math::gauss<5>(b, a, modulus);
-      P.a1 = a[0];
-      P.a2 = a[1];
-      P.a3 = a[2];
-      P.a4 = a[3];
-      P.a5 = a[4];
-      S.r1 = q4;
-      S.r2 = q3;
-      S.r3 = q2;
-      S.r4 = q1;
-      S.r5 = q0;
-      for (int i = 0; i < 5; ++i)
+      P.a[0] = a[0];
+      P.a[1] = a[1];
+      P.a[2] = a[2];
+      P.a[3] = a[3];
+      P.a[4] = a[4];
+      S.r[0] = q4;
+      S.r[1] = q3;
+      S.r[2] = q2;
+      S.r[3] = q1;
+      S.r[4] = q0;
+      for (int i{0}; i < 5; ++i)
         backward();
     }
   }
 
   TRNG_CUDA_ENABLE
   inline void yarn5s::jump2(unsigned int s) {
-    int32_t b[25], c[25], d[5], r[5];
-    int32_t t1(P.a1), t2(P.a2), t3(P.a3), t4(P.a4), t5(P.a5);
-    b[0] = P.a1;
-    b[1] = P.a2;
-    b[2] = P.a3;
-    b[3] = P.a4;
-    b[4] = P.a5;
+    result_type b[25], c[25]{};
+    b[0] = P.a[0];
+    b[1] = P.a[1];
+    b[2] = P.a[2];
+    b[3] = P.a[3];
+    b[4] = P.a[4];
     b[5] = 1;
     b[6] = 0;
     b[7] = 0;
@@ -387,36 +302,30 @@ namespace trng {
     b[22] = 0;
     b[23] = 1;
     b[24] = 0;
-    for (unsigned int i(0); i < s; ++i)
-      if ((i & 1) == 0)
-        int_math::matrix_mult<5>(b, b, c, modulus);
-      else
-        int_math::matrix_mult<5>(c, c, b, modulus);
-    r[0] = S.r1;
-    r[1] = S.r2;
-    r[2] = S.r3;
-    r[3] = S.r4;
-    r[4] = S.r5;
-    if ((s & 1) == 0)
+    for (unsigned int i{0}; i < s; ++i) {
+      int_math::matrix_mult<5>(b, b, c, modulus);
+      ++i;
+      if (not(i < s))
+        break;
+      int_math::matrix_mult<5>(c, c, b, modulus);
+    }
+    const result_type r[5]{S.r[0], S.r[1], S.r[2], S.r[3], S.r[4]};
+    result_type d[5];
+    if ((s & 1u) == 0)
       int_math::matrix_vec_mult<5>(b, r, d, modulus);
     else
       int_math::matrix_vec_mult<5>(c, r, d, modulus);
-    S.r1 = d[0];
-    S.r2 = d[1];
-    S.r3 = d[2];
-    S.r4 = d[3];
-    S.r5 = d[4];
-    P.a1 = t1;
-    P.a2 = t2;
-    P.a3 = t3;
-    P.a4 = t4;
-    P.a5 = t5;
+    S.r[0] = d[0];
+    S.r[1] = d[1];
+    S.r[2] = d[2];
+    S.r[3] = d[3];
+    S.r[4] = d[4];
   }
 
   TRNG_CUDA_ENABLE
   inline void yarn5s::jump(unsigned long long s) {
     if (s < 16) {
-      for (unsigned int i(0); i < s; ++i)
+      for (unsigned int i{0}; i < s; ++i)
         step();
     } else {
       unsigned int i(0);
@@ -424,94 +333,94 @@ namespace trng {
         if (s % 2 == 1)
           jump2(i);
         ++i;
-        s >>= 1;
+        s >>= 1u;
       }
     }
   }
 
   TRNG_CUDA_ENABLE
-  inline void yarn5s::discard(unsigned long long n) { return jump(n); }
+  inline void yarn5s::discard(unsigned long long n) { jump(n); }
 
   TRNG_CUDA_ENABLE
   inline void yarn5s::backward() {
     result_type t;
-    if (P.a5 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    if (P.a[4] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a3) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[2]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a4) * static_cast<int64_t>(S.r5)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[3]) * static_cast<int64_t>(S.r[4])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a5, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[4], modulus))) %
           modulus);
-    } else if (P.a4 != 0) {
-      t = S.r1;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r2)) %
-                                    modulus);
+    } else if (P.a[3] != 0) {
+      t = S.r[0];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[1])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a3) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[2]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a4, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[3], modulus))) %
           modulus);
-    } else if (P.a3 != 0) {
-      t = S.r2;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r3)) %
-                                    modulus);
+    } else if (P.a[2] != 0) {
+      t = S.r[1];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[2])) % modulus);
       if (t < 0)
         t += modulus;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a2) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[1]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a3, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[2], modulus))) %
           modulus);
-    } else if (P.a2 != 0) {
-      t = S.r3;
-      t -= static_cast<result_type>((static_cast<int64_t>(P.a1) * static_cast<int64_t>(S.r4)) %
-                                    modulus);
+    } else if (P.a[1] != 0) {
+      t = S.r[2];
+      t -= static_cast<result_type>(
+          (static_cast<int64_t>(P.a[0]) * static_cast<int64_t>(S.r[3])) % modulus);
       if (t < 0)
         t += modulus;
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a2, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[1], modulus))) %
           modulus);
-    } else if (P.a1 != 0) {
-      t = S.r4;
+    } else if (P.a[0] != 0) {
+      t = S.r[3];
       t = static_cast<result_type>(
           (static_cast<int64_t>(t) *
-           static_cast<int64_t>(int_math::modulo_invers(P.a1, modulus))) %
+           static_cast<int64_t>(int_math::modulo_invers(P.a[0], modulus))) %
           modulus);
     } else
       t = 0;
-    S.r1 = S.r2;
-    S.r2 = S.r3;
-    S.r3 = S.r4;
-    S.r4 = S.r5;
-    S.r5 = t;
+    S.r[0] = S.r[1];
+    S.r[1] = S.r[2];
+    S.r[2] = S.r[3];
+    S.r[3] = S.r[4];
+    S.r[4] = t;
   }
 
 }  // namespace trng

--- a/inst/include/trng/zero_truncated_poisson_dist.hpp
+++ b/inst/include/trng/zero_truncated_poisson_dist.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -49,21 +49,19 @@ namespace trng {
   // non-uniform random number generator class
   class zero_truncated_poisson_dist {
   public:
-    typedef int result_type;
-    class param_type;
+    using result_type = int;
 
     class param_type {
     private:
-      double mu_;
+      double mu_{0};
       std::vector<double> P_;
 
       void calc_probabilities() {
         P_ = std::vector<double>();
-        int x = 1;
-        double p = 0;
-        P_.push_back(p);
+        int x{1};
+        P_.push_back(0);
         while (x < 7 or x < 2 * mu_) {
-          p = (math::exp(mu_) * math::GammaQ(x + 1.0, mu_) - 1) / math::expm1(mu_);
+          const double p{(math::exp(mu_) * math::GammaQ(x + 1.0, mu_) - 1) / math::expm1(mu_)};
           P_.push_back(p);
           ++x;
         }
@@ -76,8 +74,8 @@ namespace trng {
         mu_ = mu_new;
         calc_probabilities();
       }
-      param_type() : mu_(0) {}
-      explicit param_type(double mu) : mu_(mu) { calc_probabilities(); }
+      param_type() = default;
+      explicit param_type(double mu) : mu_{mu} { calc_probabilities(); }
       friend class zero_truncated_poisson_dist;
     };
 
@@ -86,15 +84,15 @@ namespace trng {
 
   public:
     // constructor
-    explicit zero_truncated_poisson_dist(double mu) : P(mu) {}
-    explicit zero_truncated_poisson_dist(const param_type &P) : P(P) {}
+    explicit zero_truncated_poisson_dist(double mu) : P{mu} {}
+    explicit zero_truncated_poisson_dist(const param_type &P) : P{P} {}
     // reset internal state
     void reset() {}
     // random numbers
     template<typename R>
     int operator()(R &r) {
-      double p(utility::uniformco<double>(r));
-      int x(utility::discrete(p, P.P_.begin(), P.P_.end()));
+      double p{utility::uniformco<double>(r)};
+      int x{utility::discrete(p, P.P_.begin(), P.P_.end())};
       if (x + 1 == P.P_.size()) {
         p -= cdf(x);
         while (p > 0) {
@@ -133,13 +131,13 @@ namespace trng {
   // -------------------------------------------------------------------
 
   // EqualityComparable concept
-  inline bool operator==(const zero_truncated_poisson_dist::param_type &p1,
-                         const zero_truncated_poisson_dist::param_type &p2) {
-    return p1.mu() == p2.mu();
+  inline bool operator==(const zero_truncated_poisson_dist::param_type &P1,
+                         const zero_truncated_poisson_dist::param_type &P2) {
+    return P1.mu() == P2.mu();
   }
-  inline bool operator!=(const zero_truncated_poisson_dist::param_type &p1,
-                         const zero_truncated_poisson_dist::param_type &p2) {
-    return !(p1 == p2);
+  inline bool operator!=(const zero_truncated_poisson_dist::param_type &P1,
+                         const zero_truncated_poisson_dist::param_type &P2) {
+    return not(P1 == P2);
   }
 
   // Streamable concept
@@ -193,13 +191,13 @@ namespace trng {
   template<typename char_t, typename traits_t>
   std::basic_istream<char_t, traits_t> &operator>>(std::basic_istream<char_t, traits_t> &in,
                                                    zero_truncated_poisson_dist &g) {
-    zero_truncated_poisson_dist::param_type p;
+    zero_truncated_poisson_dist::param_type P;
     std::ios_base::fmtflags flags(in.flags());
     in.flags(std::ios_base::dec | std::ios_base::fixed | std::ios_base::left);
-    in >> utility::ignore_spaces() >> utility::delim("[zero-truncated poisson ") >> p >>
+    in >> utility::ignore_spaces() >> utility::delim("[zero-truncated poisson ") >> P >>
         utility::delim(']');
     if (in)
-      g.param(p);
+      g.param(P);
     in.flags(flags);
     return in;
   }

--- a/inst/tools/fix_uninitialized-memory_read_access-backport-v4.23.patch
+++ b/inst/tools/fix_uninitialized-memory_read_access-backport-v4.23.patch
@@ -1,0 +1,40 @@
+diff --git a/trng/utility.hpp b/trng/utility.hpp
+index 52b3739..458c3b1 100644
+--- a/trng/utility.hpp
++++ b/trng/utility.hpp
+@@ -89,9 +89,9 @@ namespace trng {
+       template<typename char_t, typename traits_t>
+       friend std::basic_istream<char_t, traits_t> &operator>>(
+           std::basic_istream<char_t, traits_t> &in, const delim_str &d) {
+-        char c;
++        char c{0};
+         std::size_t len{std::strlen(d.str)}, i{0};
+-        while (i < len and !(in.get(c) and c != d.str[i])) {
++        while (i < len and not(in.get(c) and c != d.str[i])) {
+           ++i;
+         }
+         if (i < len)
+@@ -108,9 +108,8 @@ namespace trng {
+       template<typename char_t, typename traits_t>
+       friend std::basic_istream<char_t, traits_t> &operator>>(
+           std::basic_istream<char_t, traits_t> &in, const delim_c &d) {
+-        char c;
+-        in.get(c);
+-        if (c != d.c)
++        char c{0};
++        if (not in.get(c).good() or c != d.c)
+           in.setstate(std::ios::failbit);
+         return in;
+       }
+@@ -127,9 +126,9 @@ namespace trng {
+       template<typename char_t, typename traits_t>
+       friend std::basic_istream<char_t, traits_t> &operator>>(
+           std::basic_istream<char_t, traits_t> &in, const ignore_spaces_cl &) {
+-        while (true) {
++        while (in.good()) {
+           const int c(in.peek());
+-          if (c == EOF or !(c == ' ' or c == '\t' or c == '\n'))
++          if (c == traits_t::eof() or not(c == ' ' or c == '\t' or c == '\n'))
+             break;
+           in.get();
+         }

--- a/inst/tools/upgradeTRNG.R
+++ b/inst/tools/upgradeTRNG.R
@@ -1,6 +1,6 @@
 if (FALSE) {
   source("inst/tools/upgradeTRNG.R")
-  upgradeTRNG(version = "4.23")
+  upgradeTRNG(version = "4.23.1")
   # with patch, packported from trng4 @22cc3b6:
   patch_file <- file.path(getwd(), "inst", "tools", "fix_uninitialized-memory_read_access-backport-v4.23.patch")
   system(paste0("cd ~/GitHubProjects/trng4/ && git diff v4.23..22cc3b6 trng/utility.hpp > ", patch_file))
@@ -14,7 +14,7 @@ upgradeTRNG <- function(version, base_url = "https://numbercrunch.de/trng",
                         cleanTmp = TRUE) {
 
   pre_4.22 <- package_version(version) < package_version("4.22")
-  gh_only <- package_version(version) == package_version("4.23")
+  gh_only <- package_version(version) >= package_version("4.23")
   lib.tar.gz <- sprintf("trng-%s.tar.gz", version)
   if (gh_only) {
     gh_base_url <- "https://github.com/rabauke/trng4/archive"

--- a/inst/tools/upgradeTRNG.R
+++ b/inst/tools/upgradeTRNG.R
@@ -1,14 +1,20 @@
 # source("inst/tools/upgradeTRNG.R")
-# upgradeTRNG(version = "4.22")
+# upgradeTRNG(version = "4.23")
 # # off-line:
-# upgradeTRNG(version = "4.22", sprintf("file://%s", normalizePath("~/Downloads")))
+# upgradeTRNG(version = "4.23", sprintf("file://%s", normalizePath("~/Downloads")))
 
 upgradeTRNG <- function(version, base_url = "https://numbercrunch.de/trng",
                         cleanTmp = TRUE) {
 
   pre_4.22 <- package_version(version) < package_version("4.22")
+  gh_only <- package_version(version) == package_version("4.23")
   lib.tar.gz <- sprintf("trng-%s.tar.gz", version)
+  if (gh_only) {
+    gh_base_url <- "https://github.com/rabauke/trng4/archive"
+    libURL <- sprintf("%s/v%s.tar.gz", gh_base_url, version)
+  } else {
   libURL <- sprintf("%s/%s", base_url, lib.tar.gz)
+  }
   tmpDir <- tempdir()
   lib.tar.gz.path <- file.path(tmpDir, lib.tar.gz)
 

--- a/inst/tools/upgradeTRNG.R
+++ b/inst/tools/upgradeTRNG.R
@@ -1,6 +1,6 @@
 if (FALSE) {
   source("inst/tools/upgradeTRNG.R")
-  upgradeTRNG(version = "4.23.1")
+  upgradeTRNG(version = "4.23.1", year = "2021")
   # with patch, packported from trng4 @22cc3b6:
   patch_file <- file.path(getwd(), "inst", "tools", "fix_uninitialized-memory_read_access-backport-v4.23.patch")
   system(paste0("cd ~/GitHubProjects/trng4/ && git diff v4.23..22cc3b6 trng/utility.hpp > ", patch_file))
@@ -10,6 +10,7 @@ if (FALSE) {
 }
 
 upgradeTRNG <- function(version, base_url = "https://numbercrunch.de/trng",
+                        year = "0000",
                         patch = NULL,
                         cleanTmp = TRUE) {
 
@@ -17,10 +18,12 @@ upgradeTRNG <- function(version, base_url = "https://numbercrunch.de/trng",
   gh_only <- package_version(version) >= package_version("4.23")
   lib.tar.gz <- sprintf("trng-%s.tar.gz", version)
   if (gh_only) {
-    gh_base_url <- "https://github.com/rabauke/trng4/archive"
-    libURL <- sprintf("%s/v%s.tar.gz", gh_base_url, version)
+    gh_base_url <- "https://github.com/rabauke/trng4"
+    libURL <- sprintf("%s/archive/v%s.tar.gz", gh_base_url, version)
+    docURL <- sprintf("%s/tree/v%s/doc/trng.pdf", gh_base_url, version)
   } else {
     libURL <- sprintf("%s/%s", base_url, lib.tar.gz)
+    docURL <- "https://numbercrunch.de/trng/trng.pdf"
   }
   tmpDir <- tempdir()
   lib.tar.gz.path <- file.path(tmpDir, lib.tar.gz)
@@ -107,7 +110,22 @@ upgradeTRNG <- function(version, base_url = "https://numbercrunch.de/trng",
   message("Update DESCRIPTION with version ", rTRNG.version)
   description.text <- sub("(Version: ).*$", paste0("\\1", rTRNG.version),
                           readLines("DESCRIPTION"))
+  message("Update DESCRIPTION with documentation year ", year)
+  description.text <- sub("Bauke \\(\\d{4}\\)$",
+                          sprintf("Bauke (%s)", year),
+                          description.text)
+  message("Update DESCRIPTION with documentation URL <", docURL, ">")
+  description.text <- sub("<.*/trng[.]pdf>",
+                          sprintf("<%s>", docURL),
+                          description.text)
   writeLines(description.text, "DESCRIPTION")
+
+  message("Update TRNG reference URL <", docURL, ">")
+  reference.text <- sub("url\\{.*trng[.]pdf\\}",
+                        sprintf("url{%s}", docURL),
+                        readLines("man-roxygen/references-TRNG.R"))
+  writeLines(reference.text, "man-roxygen/references-TRNG.R")
+
 
   invisible()
 

--- a/inst/tools/valgrind-check.sh
+++ b/inst/tools/valgrind-check.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Run R CMD check with valgrind to collect and detect reported errors.
+#
+# It is used by the valgrind GH actions workflow and can also be run locally,
+# provided Docker is available.
+
+mkdir -p valgrind-check
+
+# Note that we use -l and --install-args="--clean" in order to not have in the
+# valgrind-check directory (uploaded as artifact in GH actions) some large
+# directories and files produced as part of R CMD check
+docker run --rm -v $(pwd):/rTRNG wch1/r-debug bash -c ' \
+  RDvalgrind -e "install.packages(\"remotes\"); remotes::install_deps(\"rTRNG\", dependencies = TRUE)" \
+  && RDvalgrind CMD build /rTRNG \
+  && mkdir valgrind-check-lib \
+  && RDvalgrind -d "valgrind --track-origins=yes" CMD check \
+    -o /rTRNG/valgrind-check \
+    -l valgrind-check-lib \
+    --install-args="--clean" \
+    --use-valgrind --no-stop-on-test-error \
+    $(ls rTRNG_*.tar.gz) \
+  '
+
+# Collect valgrind "ERROR SUMMARY" lines from all log files
+grep -ri "ERROR SUMMARY" valgrind-check/rTRNG.Rcheck --exclude-dir=*pkg_src > valgrind-check/valgrind-summary
+cat valgrind-check/valgrind-summary

--- a/man-roxygen/references-TRNG.R
+++ b/man-roxygen/references-TRNG.R
@@ -1,2 +1,2 @@
 #' @references Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-#' <%= rTRNG::TRNG.Version() %>, \url{https://numbercrunch.de/trng/trng.pdf}.
+#' <%= rTRNG::TRNG.Version() %>, \url{https://github.com/rabauke/trng4/tree/v4.23.1/doc/trng.pdf}.

--- a/man/TRNG.Engine.Rd
+++ b/man/TRNG.Engine.Rd
@@ -271,7 +271,7 @@ TRNG.Random.seed(r$.Random.seed())
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.22, \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23, \url{https://numbercrunch.de/trng/trng.pdf}.
 }
 \seealso{
 \code{\link{ReferenceClasses}}, \code{\link{TRNG.Random}}.

--- a/man/TRNG.Engine.Rd
+++ b/man/TRNG.Engine.Rd
@@ -271,7 +271,7 @@ TRNG.Random.seed(r$.Random.seed())
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23.1, \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1, \url{https://github.com/rabauke/trng4/tree/v4.23.1/doc/trng.pdf}.
 }
 \seealso{
 \code{\link{ReferenceClasses}}, \code{\link{TRNG.Random}}.

--- a/man/TRNG.Engine.Rd
+++ b/man/TRNG.Engine.Rd
@@ -271,7 +271,7 @@ TRNG.Random.seed(r$.Random.seed())
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23, \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1 (patched in rTRNG), \url{https://numbercrunch.de/trng/trng.pdf}.
 }
 \seealso{
 \code{\link{ReferenceClasses}}, \code{\link{TRNG.Random}}.

--- a/man/TRNG.Engine.Rd
+++ b/man/TRNG.Engine.Rd
@@ -271,7 +271,7 @@ TRNG.Random.seed(r$.Random.seed())
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23.1 (patched in rTRNG), \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1, \url{https://numbercrunch.de/trng/trng.pdf}.
 }
 \seealso{
 \code{\link{ReferenceClasses}}, \code{\link{TRNG.Random}}.

--- a/man/TRNG.Random.Rd
+++ b/man/TRNG.Random.Rd
@@ -195,7 +195,7 @@ c(TRNGseed(117),
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23, \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1 (patched in rTRNG), \url{https://numbercrunch.de/trng/trng.pdf}.
 }
 \seealso{
 TRNG distributions:

--- a/man/TRNG.Random.Rd
+++ b/man/TRNG.Random.Rd
@@ -195,7 +195,7 @@ c(TRNGseed(117),
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.22, \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23, \url{https://numbercrunch.de/trng/trng.pdf}.
 }
 \seealso{
 TRNG distributions:

--- a/man/TRNG.Random.Rd
+++ b/man/TRNG.Random.Rd
@@ -195,7 +195,7 @@ c(TRNGseed(117),
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23.1 (patched in rTRNG), \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1, \url{https://numbercrunch.de/trng/trng.pdf}.
 }
 \seealso{
 TRNG distributions:

--- a/man/TRNG.Random.Rd
+++ b/man/TRNG.Random.Rd
@@ -195,7 +195,7 @@ c(TRNGseed(117),
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23.1, \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1, \url{https://github.com/rabauke/trng4/tree/v4.23.1/doc/trng.pdf}.
 }
 \seealso{
 TRNG distributions:

--- a/man/rTRNG-package.Rd
+++ b/man/rTRNG-package.Rd
@@ -62,7 +62,7 @@ cases.
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23.1 (patched in rTRNG), \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1, \url{https://numbercrunch.de/trng/trng.pdf}.
 
 Stephan Mertens, \emph{Random Number Generators: A Survival Guide
   for Large Scale Simulations}, 2009,

--- a/man/rTRNG-package.Rd
+++ b/man/rTRNG-package.Rd
@@ -62,7 +62,7 @@ cases.
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23, \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1 (patched in rTRNG), \url{https://numbercrunch.de/trng/trng.pdf}.
 
 Stephan Mertens, \emph{Random Number Generators: A Survival Guide
   for Large Scale Simulations}, 2009,

--- a/man/rTRNG-package.Rd
+++ b/man/rTRNG-package.Rd
@@ -62,7 +62,7 @@ cases.
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.22, \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23, \url{https://numbercrunch.de/trng/trng.pdf}.
 
 Stephan Mertens, \emph{Random Number Generators: A Survival Guide
   for Large Scale Simulations}, 2009,

--- a/man/rTRNG-package.Rd
+++ b/man/rTRNG-package.Rd
@@ -62,7 +62,7 @@ cases.
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23.1, \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1, \url{https://github.com/rabauke/trng4/tree/v4.23.1/doc/trng.pdf}.
 
 Stephan Mertens, \emph{Random Number Generators: A Survival Guide
   for Large Scale Simulations}, 2009,

--- a/src/trng/lcg64.cc
+++ b/src/trng/lcg64.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -62,11 +62,11 @@ namespace trng {
   const lcg64::parameter_type lcg64::LEcuyer3 = parameter_type(3935559000370003845u, 1u);
 
   // Random number engine concept
-  lcg64::lcg64(lcg64::parameter_type P) : P(P), S() {}
+  lcg64::lcg64(lcg64::parameter_type P) : P{P} {}
 
-  lcg64::lcg64(unsigned long s, lcg64::parameter_type P) : P(P), S() { seed(s); }
+  lcg64::lcg64(unsigned long s, lcg64::parameter_type P) : P{P} { seed(s); }
 
-  lcg64::lcg64(unsigned long long s, lcg64::parameter_type P) : P(P), S() { seed(s); }
+  lcg64::lcg64(unsigned long long s, lcg64::parameter_type P) : P{P} { seed(s); }
 
   void lcg64::seed() { (*this) = lcg64(); }
 

--- a/src/trng/lcg64_shift.cc
+++ b/src/trng/lcg64_shift.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -68,13 +68,12 @@ namespace trng {
       parameter_type(3935559000370003845u, 1u);
 
   // Random number engine concept
-  lcg64_shift::lcg64_shift(lcg64_shift::parameter_type P) : P(P), S() {}
+  lcg64_shift::lcg64_shift(lcg64_shift::parameter_type P) : P{P} {}
 
-  lcg64_shift::lcg64_shift(unsigned long s, lcg64_shift::parameter_type P) : P(P), S() {
-    seed(s);
+  lcg64_shift::lcg64_shift(unsigned long s, lcg64_shift::parameter_type P) : P{P} { seed(s);
   }
 
-  lcg64_shift::lcg64_shift(unsigned long long s, lcg64_shift::parameter_type P) : P(P), S() {
+  lcg64_shift::lcg64_shift(unsigned long long s, lcg64_shift::parameter_type P) : P{P} {
     seed(s);
   }
 

--- a/src/trng/minstd.cc
+++ b/src/trng/minstd.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,7 @@ namespace trng {
   // Random number engine concept
   minstd::minstd() : S() {}
 
-  minstd::minstd(unsigned long s) : S() { seed(s); }
+  minstd::minstd(unsigned long s) { seed(s); }
 
   void minstd::seed() { (*this) = minstd(); }
 

--- a/src/trng/mrg2.cc
+++ b/src/trng/mrg2.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,51 +37,32 @@ namespace trng {
   // Uniform random number generator concept
 
   // Parameter and status classes
-
-  // EqualityComparable concept
-  bool operator==(const mrg2::parameter_type &P1, const mrg2::parameter_type &P2) {
-    return P1.a1 == P2.a1 and P1.a2 == P2.a2;
-  }
-
-  bool operator!=(const mrg2::parameter_type &P1, const mrg2::parameter_type &P2) {
-    return not(P1 == P2);
-  }
-
-  // Equality comparable concept
-  bool operator==(const mrg2::status_type &S1, const mrg2::status_type &S2) {
-    return S1.r1 == S2.r1 and S1.r2 == S2.r2;
-  }
-
-  bool operator!=(const mrg2::status_type &S1, const mrg2::status_type &S2) {
-    return not(S1 == S2);
-  }
-
   const mrg2::parameter_type mrg2::LEcuyer1 = parameter_type(1498809829, 1160990996);
   const mrg2::parameter_type mrg2::LEcuyer2 = parameter_type(46325, 1084587);
 
   // Random number engine concept
-  mrg2::mrg2(mrg2::parameter_type P) : P(P), S() {}
+  mrg2::mrg2(mrg2::parameter_type P) : P{P} {}
 
-  mrg2::mrg2(unsigned long s, mrg2::parameter_type P) : P(P), S() { seed(s); }
+  mrg2::mrg2(unsigned long s, mrg2::parameter_type P) : P{P} { seed(s); }
 
   void mrg2::seed() { (*this) = mrg2(); }
 
   void mrg2::seed(unsigned long s) {
-    long long t = s;
+    int64_t t(s);
     t %= modulus;
     if (t < 0)
       t += modulus;
-    S.r1 = static_cast<result_type>(t);
-    S.r2 = 1;
+    S.r[0] = static_cast<result_type>(t);
+    S.r[1] = 1;
   }
 
   void mrg2::seed(mrg2::result_type s1, mrg2::result_type s2) {
-    S.r1 = s1 % modulus;
-    if (S.r1 < 0)
-      S.r1 += modulus;
-    S.r2 = s2 % modulus;
-    if (S.r2 < 0)
-      S.r2 += modulus;
+    S.r[0] = s1 % modulus;
+    if (S.r[0] < 0)
+      S.r[0] += modulus;
+    S.r[1] = s2 % modulus;
+    if (S.r[1] < 0)
+      S.r[1] += modulus;
   }
 
   // Equality comparable concept

--- a/src/trng/mrg3.cc
+++ b/src/trng/mrg3.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,57 +37,38 @@ namespace trng {
   // Uniform random number generator concept
 
   // Parameter and status classes
-
-  // EqualityComparable concept
-  bool operator==(const mrg3::parameter_type &P1, const mrg3::parameter_type &P2) {
-    return P1.a1 == P2.a1 and P1.a2 == P2.a2 and P1.a3 == P2.a3;
-  }
-
-  bool operator!=(const mrg3::parameter_type &P1, const mrg3::parameter_type &P2) {
-    return not(P1 == P2);
-  }
-
-  // Equality comparable concept
-  bool operator==(const mrg3::status_type &S1, const mrg3::status_type &S2) {
-    return S1.r1 == S2.r1 and S1.r2 == S2.r2 and S1.r3 == S2.r3;
-  }
-
-  bool operator!=(const mrg3::status_type &S1, const mrg3::status_type &S2) {
-    return not(S1 == S2);
-  }
-
   const mrg3::parameter_type mrg3::LEcuyer1 =
       parameter_type(2021422057, 1826992351, 1977753457);
   const mrg3::parameter_type mrg3::LEcuyer2 = parameter_type(1476728729l, 0, 1155643113);
   const mrg3::parameter_type mrg3::LEcuyer3 = parameter_type(65338, 0, 64636);
 
   // Random number engine concept
-  mrg3::mrg3(mrg3::parameter_type P) : P(P), S() {}
+  mrg3::mrg3(mrg3::parameter_type P) : P{P} {}
 
-  mrg3::mrg3(unsigned long s, mrg3::parameter_type P) : P(P), S() { seed(s); }
+  mrg3::mrg3(unsigned long s, mrg3::parameter_type P) : P{P} { seed(s); }
 
   void mrg3::seed() { (*this) = mrg3(); }
 
   void mrg3::seed(unsigned long s) {
-    long long t = s;
+    int64_t t(s);
     t %= modulus;
     if (t < 0)
       t += modulus;
-    S.r1 = static_cast<result_type>(t);
-    S.r2 = 1;
-    S.r3 = 1;
+    S.r[0] = static_cast<result_type>(t);
+    S.r[1] = 1;
+    S.r[2] = 1;
   }
 
   void mrg3::seed(mrg3::result_type s1, mrg3::result_type s2, mrg3::result_type s3) {
-    S.r1 = s1 % modulus;
-    if (S.r1 < 0)
-      S.r1 += modulus;
-    S.r2 = s2 % modulus;
-    if (S.r2 < 0)
-      S.r2 += modulus;
-    S.r3 = s3 % modulus;
-    if (S.r3 < 0)
-      S.r3 += modulus;
+    S.r[0] = s1 % modulus;
+    if (S.r[0] < 0)
+      S.r[0] += modulus;
+    S.r[1] = s2 % modulus;
+    if (S.r[1] < 0)
+      S.r[1] += modulus;
+    S.r[2] = s3 % modulus;
+    if (S.r[2] < 0)
+      S.r[2] += modulus;
   }
 
   // Equality comparable concept

--- a/src/trng/mrg3s.cc
+++ b/src/trng/mrg3s.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,55 +37,36 @@ namespace trng {
   // Uniform random number generator concept
 
   // Parameter and status classes
-
-  // EqualityComparable concept
-  bool operator==(const mrg3s::parameter_type &P1, const mrg3s::parameter_type &P2) {
-    return P1.a1 == P2.a1 and P1.a2 == P2.a2 and P1.a3 == P2.a3;
-  }
-
-  bool operator!=(const mrg3s::parameter_type &P1, const mrg3s::parameter_type &P2) {
-    return not(P1 == P2);
-  }
-
-  // Equality comparable concept
-  bool operator==(const mrg3s::status_type &S1, const mrg3s::status_type &S2) {
-    return S1.r1 == S2.r1 and S1.r2 == S2.r2 and S1.r3 == S2.r3;
-  }
-
-  bool operator!=(const mrg3s::status_type &S1, const mrg3s::status_type &S2) {
-    return not(S1 == S2);
-  }
-
   const mrg3s::parameter_type mrg3s::trng0 = parameter_type(2025213985, 1112953677, 2038969601);
   const mrg3s::parameter_type mrg3s::trng1 = parameter_type(1287767370, 1045931779, 58150106);
 
   // Random number engine concept
-  mrg3s::mrg3s(mrg3s::parameter_type P) : P(P), S() {}
+  mrg3s::mrg3s(mrg3s::parameter_type P) : P{P} {}
 
-  mrg3s::mrg3s(unsigned long s, mrg3s::parameter_type P) : P(P), S() { seed(s); }
+  mrg3s::mrg3s(unsigned long s, mrg3s::parameter_type P) : P{P} { seed(s); }
 
   void mrg3s::seed() { (*this) = mrg3s(); }
 
   void mrg3s::seed(unsigned long s) {
-    int64_t t = s;
+    int64_t t(s);
     t %= modulus;
     if (t < 0)
       t += modulus;
-    S.r1 = static_cast<result_type>(t);
-    S.r2 = 1;
-    S.r3 = 1;
+    S.r[0] = static_cast<result_type>(t);
+    S.r[1] = 1;
+    S.r[2] = 1;
   }
 
   void mrg3s::seed(mrg3s::result_type s1, mrg3s::result_type s2, mrg3s::result_type s3) {
-    S.r1 = s1 % modulus;
-    if (S.r1 < 0)
-      S.r1 += modulus;
-    S.r2 = s2 % modulus;
-    if (S.r2 < 0)
-      S.r2 += modulus;
-    S.r3 = s3 % modulus;
-    if (S.r3 < 0)
-      S.r3 += modulus;
+    S.r[0] = s1 % modulus;
+    if (S.r[0] < 0)
+      S.r[0] += modulus;
+    S.r[1] = s2 % modulus;
+    if (S.r[1] < 0)
+      S.r[1] += modulus;
+    S.r[2] = s3 % modulus;
+    if (S.r[2] < 0)
+      S.r[2] += modulus;
   }
 
   // Equality comparable concept

--- a/src/trng/mrg4.cc
+++ b/src/trng/mrg4.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,61 +37,42 @@ namespace trng {
   // Uniform random number generator concept
 
   // Parameter and status classes
-
-  // EqualityComparable concept
-  bool operator==(const mrg4::parameter_type &P1, const mrg4::parameter_type &P2) {
-    return P1.a1 == P2.a1 and P1.a2 == P2.a2 and P1.a3 == P2.a3 and P1.a4 == P2.a4;
-  }
-
-  bool operator!=(const mrg4::parameter_type &P1, const mrg4::parameter_type &P2) {
-    return not(P1 == P2);
-  }
-
-  // Equality comparable concept
-  bool operator==(const mrg4::status_type &S1, const mrg4::status_type &S2) {
-    return S1.r1 == S2.r1 and S1.r2 == S2.r2 and S1.r3 == S2.r3 and S1.r4 == S2.r4;
-  }
-
-  bool operator!=(const mrg4::status_type &S1, const mrg4::status_type &S2) {
-    return not(S1 == S2);
-  }
-
   const mrg4::parameter_type mrg4::LEcuyer1 =
       parameter_type(2001982722, 1412284257, 1155380217, 1668339922);
   const mrg4::parameter_type mrg4::LEcuyer2 = parameter_type(64886, 0, 0, 64322);
 
   // Random number engine concept
-  mrg4::mrg4(mrg4::parameter_type P) : P(P), S() {}
+  mrg4::mrg4(mrg4::parameter_type P) : P{P} {}
 
-  mrg4::mrg4(unsigned long s, mrg4::parameter_type P) : P(P), S() { seed(s); }
+  mrg4::mrg4(unsigned long s, mrg4::parameter_type P) : P{P} { seed(s); }
 
   void mrg4::seed() { (*this) = mrg4(); }
 
   void mrg4::seed(unsigned long s) {
-    int64_t t = s;
+    int64_t t(s);
     t %= modulus;
     if (t < 0)
       t += modulus;
-    S.r1 = static_cast<result_type>(t);
-    S.r2 = 1;
-    S.r3 = 1;
-    S.r4 = 1;
+    S.r[0] = static_cast<result_type>(t);
+    S.r[1] = 1;
+    S.r[2] = 1;
+    S.r[3] = 1;
   }
 
   void mrg4::seed(mrg4::result_type s1, mrg4::result_type s2, mrg4::result_type s3,
                   mrg4::result_type s4) {
-    S.r1 = s1 % modulus;
-    if (S.r1 < 0)
-      S.r1 += modulus;
-    S.r2 = s2 % modulus;
-    if (S.r2 < 0)
-      S.r2 += modulus;
-    S.r3 = s3 % modulus;
-    if (S.r3 < 0)
-      S.r3 += modulus;
-    S.r4 = s4 % modulus;
-    if (S.r4 < 0)
-      S.r4 += modulus;
+    S.r[0] = s1 % modulus;
+    if (S.r[0] < 0)
+      S.r[0] += modulus;
+    S.r[1] = s2 % modulus;
+    if (S.r[1] < 0)
+      S.r[1] += modulus;
+    S.r[2] = s3 % modulus;
+    if (S.r[2] < 0)
+      S.r[2] += modulus;
+    S.r[3] = s4 % modulus;
+    if (S.r[3] < 0)
+      S.r[3] += modulus;
   }
 
   // Equality comparable concept

--- a/src/trng/mrg5.cc
+++ b/src/trng/mrg5.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,65 +37,44 @@ namespace trng {
   // Uniform random number generator concept
 
   // Parameter and status classes
-
-  // EqualityComparable concept
-  bool operator==(const mrg5::parameter_type &P1, const mrg5::parameter_type &P2) {
-    return P1.a1 == P2.a1 and P1.a2 == P2.a2 and P1.a3 == P2.a3 and P1.a4 == P2.a4 and
-           P1.a5 == P2.a5;
-  }
-
-  bool operator!=(const mrg5::parameter_type &P1, const mrg5::parameter_type &P2) {
-    return not(P1 == P2);
-  }
-
-  // Equality comparable concept
-  bool operator==(const mrg5::status_type &S1, const mrg5::status_type &S2) {
-    return S1.r1 == S2.r1 and S1.r2 == S2.r2 and S1.r3 == S2.r3 and S1.r4 == S2.r4 and
-           S1.r5 == S2.r5;
-  }
-
-  bool operator!=(const mrg5::status_type &S1, const mrg5::status_type &S2) {
-    return not(S1 == S2);
-  }
-
   const mrg5::parameter_type mrg5::LEcuyer1 = parameter_type(107374182l, 0, 0, 0, 104480);
 
   // Random number engine concept
-  mrg5::mrg5(const mrg5::parameter_type &P) : P(P), S() {}
+  mrg5::mrg5(const mrg5::parameter_type &P) : P{P} {}
 
-  mrg5::mrg5(unsigned long s, const mrg5::parameter_type &P) : P(P), S() { seed(s); }
+  mrg5::mrg5(unsigned long s, const mrg5::parameter_type &P) : P{P} { seed(s); }
 
   void mrg5::seed() { (*this) = mrg5(); }
 
   void mrg5::seed(unsigned long s) {
-    int64_t t = s;
+    int64_t t(s);
     t %= modulus;
     if (t < 0)
       t += modulus;
-    S.r1 = static_cast<result_type>(t);
-    S.r2 = 1;
-    S.r3 = 1;
-    S.r4 = 1;
-    S.r5 = 1;
+    S.r[0] = static_cast<result_type>(t);
+    S.r[1] = 1;
+    S.r[2] = 1;
+    S.r[3] = 1;
+    S.r[4] = 1;
   }
 
   void mrg5::seed(mrg5::result_type s1, mrg5::result_type s2, mrg5::result_type s3,
                   mrg5::result_type s4, mrg5::result_type s5) {
-    S.r1 = s1 % modulus;
-    if (S.r1 < 0)
-      S.r1 += modulus;
-    S.r2 = s2 % modulus;
-    if (S.r2 < 0)
-      S.r2 += modulus;
-    S.r3 = s3 % modulus;
-    if (S.r3 < 0)
-      S.r3 += modulus;
-    S.r4 = s4 % modulus;
-    if (S.r4 < 0)
-      S.r4 += modulus;
-    S.r5 = s5 % modulus;
-    if (S.r5 < 0)
-      S.r5 += modulus;
+    S.r[0] = s1 % modulus;
+    if (S.r[0] < 0)
+      S.r[0] += modulus;
+    S.r[1] = s2 % modulus;
+    if (S.r[1] < 0)
+      S.r[1] += modulus;
+    S.r[2] = s3 % modulus;
+    if (S.r[2] < 0)
+      S.r[2] += modulus;
+    S.r[3] = s4 % modulus;
+    if (S.r[3] < 0)
+      S.r[3] += modulus;
+    S.r[4] = s5 % modulus;
+    if (S.r[4] < 0)
+      S.r[4] += modulus;
   }
 
   // Equality comparable concept

--- a/src/trng/mrg5s.cc
+++ b/src/trng/mrg5s.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,68 +37,47 @@ namespace trng {
   // Uniform random number generator concept
 
   // Parameter and status classes
-
-  // EqualityComparable concept
-  bool operator==(const mrg5s::parameter_type &P1, const mrg5s::parameter_type &P2) {
-    return P1.a1 == P2.a1 and P1.a2 == P2.a2 and P1.a3 == P2.a3 and P1.a4 == P2.a4 and
-           P1.a5 == P2.a5;
-  }
-
-  bool operator!=(const mrg5s::parameter_type &P1, const mrg5s::parameter_type &P2) {
-    return not(P1 == P2);
-  }
-
-  // Equality comparable concept
-  bool operator==(const mrg5s::status_type &S1, const mrg5s::status_type &S2) {
-    return S1.r1 == S2.r1 and S1.r2 == S2.r2 and S1.r3 == S2.r3 and S1.r4 == S2.r4 and
-           S1.r5 == S2.r5;
-  }
-
-  bool operator!=(const mrg5s::status_type &S1, const mrg5s::status_type &S2) {
-    return not(S1 == S2);
-  }
-
   const mrg5s::parameter_type mrg5s::trng0 =
       parameter_type(1053223373, 1530818118, 1612122482, 133497989, 573245311);
   const mrg5s::parameter_type mrg5s::trng1 =
       parameter_type(2068619238, 2138332912, 671754166, 1442240992, 1526958817);
 
   // Random number engine concept
-  mrg5s::mrg5s(const parameter_type &P) : P(P), S() {}
+  mrg5s::mrg5s(const parameter_type &P) : P{P} {}
 
-  mrg5s::mrg5s(unsigned long s, const mrg5s::parameter_type &P) : P(P), S() { seed(s); }
+  mrg5s::mrg5s(unsigned long s, const mrg5s::parameter_type &P) : P{P} { seed(s); }
 
   void mrg5s::seed() { (*this) = mrg5s(); }
 
   void mrg5s::seed(unsigned long s) {
-    int64_t t = s;
+    int64_t t(s);
     t %= modulus;
     if (t < 0)
       t += modulus;
-    S.r1 = static_cast<result_type>(t);
-    S.r2 = 1;
-    S.r3 = 1;
-    S.r4 = 1;
-    S.r5 = 1;
+    S.r[0] = static_cast<result_type>(t);
+    S.r[1] = 1;
+    S.r[2] = 1;
+    S.r[3] = 1;
+    S.r[4] = 1;
   }
 
   void mrg5s::seed(mrg5s::result_type s1, mrg5s::result_type s2, mrg5s::result_type s3,
                    mrg5s::result_type s4, mrg5s::result_type s5) {
-    S.r1 = s1 % modulus;
-    if (S.r1 < 0)
-      S.r1 += modulus;
-    S.r2 = s2 % modulus;
-    if (S.r2 < 0)
-      S.r2 += modulus;
-    S.r3 = s3 % modulus;
-    if (S.r3 < 0)
-      S.r3 += modulus;
-    S.r4 = s4 % modulus;
-    if (S.r4 < 0)
-      S.r4 += modulus;
-    S.r5 = s5 % modulus;
-    if (S.r5 < 0)
-      S.r5 += modulus;
+    S.r[0] = s1 % modulus;
+    if (S.r[0] < 0)
+      S.r[0] += modulus;
+    S.r[1] = s2 % modulus;
+    if (S.r[1] < 0)
+      S.r[1] += modulus;
+    S.r[2] = s3 % modulus;
+    if (S.r[2] < 0)
+      S.r[2] += modulus;
+    S.r[3] = s4 % modulus;
+    if (S.r[3] < 0)
+      S.r[3] += modulus;
+    S.r[4] = s5 % modulus;
+    if (S.r[4] < 0)
+      S.r[4] += modulus;
   }
 
   // Equality comparable concept

--- a/src/trng/mt19937.cc
+++ b/src/trng/mt19937.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -49,7 +49,7 @@ namespace trng {
 
   // Equality comparable concept
   bool operator==(const mt19937::status_type &S1, const mt19937::status_type &S2) {
-    for (int i = 0; i < mt19937::status_type::N; ++i)
+    for (int i{0}; i < mt19937::status_type::N; ++i)
       if (S1.mt[i] != S2.mt[i])
         return false;
     return true;
@@ -60,9 +60,9 @@ namespace trng {
   }
 
   // Random number engine concept
-  mt19937::mt19937() : P(), S() { seed(5489u); }
+  mt19937::mt19937() { seed(5489u); }
 
-  mt19937::mt19937(unsigned long s) : P(), S() { seed(s); }
+  mt19937::mt19937(unsigned long s) { seed(s); }
 
   void mt19937::seed() { (*this) = mt19937(); }
 
@@ -70,7 +70,7 @@ namespace trng {
     S.mt[0] = s & 0xffffffffU;
     for (S.mti = 1; S.mti < mt19937::N; ++S.mti)
       S.mt[S.mti] =
-          (1812433253U * (S.mt[S.mti - 1] ^ (S.mt[S.mti - 1] >> 30)) + S.mti) & 0xffffffffU;
+          (1812433253U * (S.mt[S.mti - 1] ^ (S.mt[S.mti - 1] >> 30u)) + S.mti) & 0xffffffffU;
   }
 
   // Equality comparable concept

--- a/src/trng/mt19937_64.cc
+++ b/src/trng/mt19937_64.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -49,7 +49,7 @@ namespace trng {
 
   // Equality comparable concept
   bool operator==(const mt19937_64::status_type &S1, const mt19937_64::status_type &S2) {
-    for (int i = 0; i < mt19937_64::status_type::N; ++i)
+    for (int i{0}; i < mt19937_64::status_type::N; ++i)
       if (S1.mt[i] != S2.mt[i])
         return false;
     return true;
@@ -60,9 +60,9 @@ namespace trng {
   }
 
   // Random number engine concept
-  mt19937_64::mt19937_64() : P(), S() { seed(5489u); }
+  mt19937_64::mt19937_64() { seed(5489u); }
 
-  mt19937_64::mt19937_64(unsigned long s) : P(), S() { seed(s); }
+  mt19937_64::mt19937_64(unsigned long s) { seed(s); }
 
   void mt19937_64::seed() { (*this) = mt19937_64(); }
 
@@ -70,7 +70,7 @@ namespace trng {
     S.mt[0] = s;
     for (S.mti = 1; S.mti < mt19937_64::status_type::N; ++S.mti)
       S.mt[S.mti] =
-          (6364136223846793005u * (S.mt[S.mti - 1] ^ (S.mt[S.mti - 1] >> 62)) + S.mti);
+          (6364136223846793005u * (S.mt[S.mti - 1] ^ (S.mt[S.mti - 1] >> 62u)) + S.mti);
   }
 
   // Equality comparable concept

--- a/src/trng/yarn2.cc
+++ b/src/trng/yarn2.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,51 +37,32 @@ namespace trng {
   // Uniform random number generator concept
 
   // Parameter and status classes
-
-  // EqualityComparable concept
-  bool operator==(const yarn2::parameter_type &P1, const yarn2::parameter_type &P2) {
-    return P1.a1 == P2.a1 and P1.a2 == P2.a2;
-  }
-
-  bool operator!=(const yarn2::parameter_type &P1, const yarn2::parameter_type &P2) {
-    return not(P1 == P2);
-  }
-
-  // Equality comparable concept
-  bool operator==(const yarn2::status_type &S1, const yarn2::status_type &S2) {
-    return S1.r1 == S2.r1 and S1.r2 == S2.r2;
-  }
-
-  bool operator!=(const yarn2::status_type &S1, const yarn2::status_type &S2) {
-    return not(S1 == S2);
-  }
-
   const yarn2::parameter_type yarn2::LEcuyer1 = parameter_type(1498809829, 1160990996);
   const yarn2::parameter_type yarn2::LEcuyer2 = parameter_type(46325, 1084587);
 
   // Random number engine concept
-  yarn2::yarn2(yarn2::parameter_type P) : P(P), S() {}
+  yarn2::yarn2(yarn2::parameter_type P) : P{P} {}
 
-  yarn2::yarn2(unsigned long s, yarn2::parameter_type P) : P(P), S() { seed(s); }
+  yarn2::yarn2(unsigned long s, yarn2::parameter_type P) : P{P} { seed(s); }
 
   void yarn2::seed() { (*this) = yarn2(); }
 
   void yarn2::seed(unsigned long s) {
-    int64_t t = s;
+    int64_t t(s);
     t %= modulus;
     if (t < 0)
       t += modulus;
-    S.r1 = static_cast<result_type>(t);
-    S.r2 = 1;
+    S.r[0] = static_cast<result_type>(t);
+    S.r[1] = 1;
   }
 
   void yarn2::seed(yarn2::result_type s1, yarn2::result_type s2) {
-    S.r1 = s1 % modulus;
-    if (S.r1 < 0)
-      S.r1 += modulus;
-    S.r2 = s2 % modulus;
-    if (S.r2 < 0)
-      S.r2 += modulus;
+    S.r[0] = s1 % modulus;
+    if (S.r[0] < 0)
+      S.r[0] += modulus;
+    S.r[1] = s2 % modulus;
+    if (S.r[1] < 0)
+      S.r[1] += modulus;
   }
 
   // Equality comparable concept
@@ -94,6 +75,6 @@ namespace trng {
 
   const char *yarn2::name() { return name_str; }
 
-  int_math::power<yarn2::modulus, yarn2::gen> yarn2::parameter_type::g;
+  const int_math::power<yarn2::modulus, yarn2::gen> yarn2::g;
 
 }  // namespace trng

--- a/src/trng/yarn3.cc
+++ b/src/trng/yarn3.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,57 +37,38 @@ namespace trng {
   // Uniform random number generator concept
 
   // Parameter and status classes
-
-  // EqualityComparable concept
-  bool operator==(const yarn3::parameter_type &P1, const yarn3::parameter_type &P2) {
-    return P1.a1 == P2.a1 and P1.a2 == P2.a2 and P1.a3 == P2.a3;
-  }
-
-  bool operator!=(const yarn3::parameter_type &P1, const yarn3::parameter_type &P2) {
-    return not(P1 == P2);
-  }
-
-  // Equality comparable concept
-  bool operator==(const yarn3::status_type &S1, const yarn3::status_type &S2) {
-    return S1.r1 == S2.r1 and S1.r2 == S2.r2 and S1.r3 == S2.r3;
-  }
-
-  bool operator!=(const yarn3::status_type &S1, const yarn3::status_type &S2) {
-    return not(S1 == S2);
-  }
-
   const yarn3::parameter_type yarn3::LEcuyer1 =
       parameter_type(2021422057, 1826992351, 1977753457);
   const yarn3::parameter_type yarn3::LEcuyer2 = parameter_type(1476728729, 0, 1155643113);
   const yarn3::parameter_type yarn3::LEcuyer3 = parameter_type(65338, 0, 64636);
 
   // Random number engine concept
-  yarn3::yarn3(yarn3::parameter_type P) : P(P), S() {}
+  yarn3::yarn3(yarn3::parameter_type P) : P{P} {}
 
-  yarn3::yarn3(unsigned long s, yarn3::parameter_type P) : P(P), S() { seed(s); }
+  yarn3::yarn3(unsigned long s, yarn3::parameter_type P) : P{P} { seed(s); }
 
   void yarn3::seed() { (*this) = yarn3(); }
 
   void yarn3::seed(unsigned long s) {
-    int64_t t = s;
+    int64_t t(s);
     t %= modulus;
     if (t < 0)
       t += modulus;
-    S.r1 = static_cast<result_type>(t);
-    S.r2 = 1;
-    S.r3 = 1;
+    S.r[0] = static_cast<result_type>(t);
+    S.r[1] = 1;
+    S.r[2] = 1;
   }
 
   void yarn3::seed(yarn3::result_type s1, yarn3::result_type s2, yarn3::result_type s3) {
-    S.r1 = s1 % modulus;
-    if (S.r1 < 0)
-      S.r1 += modulus;
-    S.r2 = s2 % modulus;
-    if (S.r2 < 0)
-      S.r2 += modulus;
-    S.r3 = s3 % modulus;
-    if (S.r3 < 0)
-      S.r3 += modulus;
+    S.r[0] = s1 % modulus;
+    if (S.r[0] < 0)
+      S.r[0] += modulus;
+    S.r[1] = s2 % modulus;
+    if (S.r[1] < 0)
+      S.r[1] += modulus;
+    S.r[2] = s3 % modulus;
+    if (S.r[2] < 0)
+      S.r[2] += modulus;
   }
 
   // Equality comparable concept
@@ -100,6 +81,6 @@ namespace trng {
 
   const char *yarn3::name() { return name_str; }
 
-  int_math::power<yarn3::modulus, yarn3::gen> yarn3::parameter_type::g;
+  const int_math::power<yarn3::modulus, yarn3::gen> yarn3::g;
 
 }  // namespace trng

--- a/src/trng/yarn3s.cc
+++ b/src/trng/yarn3s.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,56 +37,37 @@ namespace trng {
   // Uniform random number generator concept
 
   // Parameter and status classes
-
-  // EqualityComparable concept
-  bool operator==(const yarn3s::parameter_type &P1, const yarn3s::parameter_type &P2) {
-    return P1.a1 == P2.a1 and P1.a2 == P2.a2 and P1.a3 == P2.a3;
-  }
-
-  bool operator!=(const yarn3s::parameter_type &P1, const yarn3s::parameter_type &P2) {
-    return not(P1 == P2);
-  }
-
-  // Equality comparable concept
-  bool operator==(const yarn3s::status_type &S1, const yarn3s::status_type &S2) {
-    return S1.r1 == S2.r1 and S1.r2 == S2.r2 and S1.r3 == S2.r3;
-  }
-
-  bool operator!=(const yarn3s::status_type &S1, const yarn3s::status_type &S2) {
-    return not(S1 == S2);
-  }
-
   const yarn3s::parameter_type yarn3s::trng0 =
       parameter_type(2025213985, 1112953677, 2038969601);
   const yarn3s::parameter_type yarn3s::trng1 = parameter_type(1287767370, 1045931779, 58150106);
 
   // Random number engine concept
-  yarn3s::yarn3s(yarn3s::parameter_type P) : P(P), S() {}
+  yarn3s::yarn3s(yarn3s::parameter_type P) : P{P} {}
 
-  yarn3s::yarn3s(unsigned long s, yarn3s::parameter_type P) : P(P), S() { seed(s); }
+  yarn3s::yarn3s(unsigned long s, yarn3s::parameter_type P) : P{P} { seed(s); }
 
   void yarn3s::seed() { (*this) = yarn3s(); }
 
   void yarn3s::seed(unsigned long s) {
-    int64_t t = s;
+    int64_t t(s);
     t %= modulus;
     if (t < 0)
       t += modulus;
-    S.r1 = static_cast<result_type>(t);
-    S.r2 = 1;
-    S.r3 = 1;
+    S.r[0] = static_cast<result_type>(t);
+    S.r[1] = 1;
+    S.r[2] = 1;
   }
 
   void yarn3s::seed(yarn3s::result_type s1, yarn3s::result_type s2, yarn3s::result_type s3) {
-    S.r1 = s1 % modulus;
-    if (S.r1 < 0)
-      S.r1 += modulus;
-    S.r2 = s2 % modulus;
-    if (S.r2 < 0)
-      S.r2 += modulus;
-    S.r3 = s3 % modulus;
-    if (S.r3 < 0)
-      S.r3 += modulus;
+    S.r[0] = s1 % modulus;
+    if (S.r[0] < 0)
+      S.r[0] += modulus;
+    S.r[1] = s2 % modulus;
+    if (S.r[1] < 0)
+      S.r[1] += modulus;
+    S.r[2] = s3 % modulus;
+    if (S.r[2] < 0)
+      S.r[2] += modulus;
   }
 
   // Equality comparable concept
@@ -99,6 +80,6 @@ namespace trng {
 
   const char *yarn3s::name() { return name_str; }
 
-  int_math::power<yarn3s::modulus, yarn3s::gen> yarn3s::parameter_type::g;
+  const int_math::power<yarn3s::modulus, yarn3s::gen> yarn3s::g;
 
 }  // namespace trng

--- a/src/trng/yarn4.cc
+++ b/src/trng/yarn4.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,61 +37,42 @@ namespace trng {
   // Uniform random number generator concept
 
   // Parameter and status classes
-
-  // EqualityComparable concept
-  bool operator==(const yarn4::parameter_type &P1, const yarn4::parameter_type &P2) {
-    return P1.a1 == P2.a1 and P1.a2 == P2.a2 and P1.a3 == P2.a3 and P1.a4 == P2.a4;
-  }
-
-  bool operator!=(const yarn4::parameter_type &P1, const yarn4::parameter_type &P2) {
-    return not(P1 == P2);
-  }
-
-  // Equality comparable concept
-  bool operator==(const yarn4::status_type &S1, const yarn4::status_type &S2) {
-    return S1.r1 == S2.r1 and S1.r2 == S2.r2 and S1.r3 == S2.r3 and S1.r4 == S2.r4;
-  }
-
-  bool operator!=(const yarn4::status_type &S1, const yarn4::status_type &S2) {
-    return not(S1 == S2);
-  }
-
   const yarn4::parameter_type yarn4::LEcuyer1 =
       parameter_type(2001982722, 1412284257, 1155380217, 1668339922);
   const yarn4::parameter_type yarn4::LEcuyer2 = parameter_type(64886, 0, 0, 64322);
 
   // Random number engine concept
-  yarn4::yarn4(yarn4::parameter_type P) : P(P), S() {}
+  yarn4::yarn4(yarn4::parameter_type P) : P{P} {}
 
-  yarn4::yarn4(unsigned long s, yarn4::parameter_type P) : P(P), S() { seed(s); }
+  yarn4::yarn4(unsigned long s, yarn4::parameter_type P) : P{P} { seed(s); }
 
   void yarn4::seed() { (*this) = yarn4(); }
 
   void yarn4::seed(unsigned long s) {
-    int64_t t = s;
+    int64_t t(s);
     t %= modulus;
     if (t < 0)
       t += modulus;
-    S.r1 = static_cast<result_type>(t);
-    S.r2 = 1;
-    S.r3 = 1;
-    S.r4 = 1;
+    S.r[0] = static_cast<result_type>(t);
+    S.r[1] = 1;
+    S.r[2] = 1;
+    S.r[3] = 1;
   }
 
   void yarn4::seed(yarn4::result_type s1, yarn4::result_type s2, yarn4::result_type s3,
                    yarn4::result_type s4) {
-    S.r1 = s1 % modulus;
-    if (S.r1 < 0)
-      S.r1 += modulus;
-    S.r2 = s2 % modulus;
-    if (S.r2 < 0)
-      S.r2 += modulus;
-    S.r3 = s3 % modulus;
-    if (S.r3 < 0)
-      S.r3 += modulus;
-    S.r4 = s4 % modulus;
-    if (S.r4 < 0)
-      S.r4 += modulus;
+    S.r[0] = s1 % modulus;
+    if (S.r[0] < 0)
+      S.r[0] += modulus;
+    S.r[1] = s2 % modulus;
+    if (S.r[1] < 0)
+      S.r[1] += modulus;
+    S.r[2] = s3 % modulus;
+    if (S.r[2] < 0)
+      S.r[2] += modulus;
+    S.r[3] = s4 % modulus;
+    if (S.r[3] < 0)
+      S.r[3] += modulus;
   }
 
   // Equality comparable concept
@@ -104,6 +85,6 @@ namespace trng {
 
   const char *yarn4::name() { return name_str; }
 
-  int_math::power<yarn4::modulus, yarn4::gen> yarn4::parameter_type::g;
+  const int_math::power<yarn4::modulus, yarn4::gen> yarn4::g;
 
 }  // namespace trng

--- a/src/trng/yarn5.cc
+++ b/src/trng/yarn5.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,27 +37,6 @@ namespace trng {
   // Uniform random number generator concept
 
   // Parameter and status classes
-
-  // EqualityComparable concept
-  bool operator==(const yarn5::parameter_type &P1, const yarn5::parameter_type &P2) {
-    return P1.a1 == P2.a1 and P1.a2 == P2.a2 and P1.a3 == P2.a3 and P1.a4 == P2.a4 and
-           P1.a5 == P2.a5;
-  }
-
-  bool operator!=(const yarn5::parameter_type &P1, const yarn5::parameter_type &P2) {
-    return not(P1 == P2);
-  }
-
-  // Equality comparable concept
-  bool operator==(const yarn5::status_type &S1, const yarn5::status_type &S2) {
-    return S1.r1 == S2.r1 and S1.r2 == S2.r2 and S1.r3 == S2.r3 and S1.r4 == S2.r4 and
-           S1.r5 == S2.r5;
-  }
-
-  bool operator!=(const yarn5::status_type &S1, const yarn5::status_type &S2) {
-    return not(S1 == S2);
-  }
-
   const yarn5::parameter_type yarn5::LEcuyer1 = parameter_type(107374182, 0, 0, 0, 104480);
 
   // Random number engine concept
@@ -72,30 +51,30 @@ namespace trng {
     t %= modulus;
     if (t < 0)
       t += modulus;
-    S.r1 = static_cast<result_type>(t);
-    S.r2 = 1;
-    S.r3 = 1;
-    S.r4 = 1;
-    S.r5 = 1;
+    S.r[0] = static_cast<result_type>(t);
+    S.r[1] = 1;
+    S.r[2] = 1;
+    S.r[3] = 1;
+    S.r[4] = 1;
   }
 
   void yarn5::seed(yarn5::result_type s1, yarn5::result_type s2, yarn5::result_type s3,
                    yarn5::result_type s4, yarn5::result_type s5) {
-    S.r1 = s1 % modulus;
-    if (S.r1 < 0)
-      S.r1 += modulus;
-    S.r2 = s2 % modulus;
-    if (S.r2 < 0)
-      S.r2 += modulus;
-    S.r3 = s3 % modulus;
-    if (S.r3 < 0)
-      S.r3 += modulus;
-    S.r4 = s4 % modulus;
-    if (S.r4 < 0)
-      S.r4 += modulus;
-    S.r5 = s5 % modulus;
-    if (S.r5 < 0)
-      S.r5 += modulus;
+    S.r[0] = s1 % modulus;
+    if (S.r[0] < 0)
+      S.r[0] += modulus;
+    S.r[1] = s2 % modulus;
+    if (S.r[1] < 0)
+      S.r[1] += modulus;
+    S.r[2] = s3 % modulus;
+    if (S.r[2] < 0)
+      S.r[2] += modulus;
+    S.r[3] = s4 % modulus;
+    if (S.r[3] < 0)
+      S.r[3] += modulus;
+    S.r[4] = s5 % modulus;
+    if (S.r[4] < 0)
+      S.r[4] += modulus;
   }
 
   // Equality comparable concept
@@ -108,6 +87,6 @@ namespace trng {
 
   const char *yarn5::name() { return name_str; }
 
-  int_math::power<yarn5::modulus, yarn5::gen> yarn5::parameter_type::g;
+  const int_math::power<yarn5::modulus, yarn5::gen> yarn5::g;
 
 }  // namespace trng

--- a/src/trng/yarn5s.cc
+++ b/src/trng/yarn5s.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2000-2019, Heiko Bauke
+// Copyright (c) 2000-2020, Heiko Bauke
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,36 +37,15 @@ namespace trng {
   // Uniform random number generator concept
 
   // Parameter and status classes
-
-  // EqualityComparable concept
-  bool operator==(const yarn5s::parameter_type &P1, const yarn5s::parameter_type &P2) {
-    return P1.a1 == P2.a1 and P1.a2 == P2.a2 and P1.a3 == P2.a3 and P1.a4 == P2.a4 and
-           P1.a5 == P2.a5;
-  }
-
-  bool operator!=(const yarn5s::parameter_type &P1, const yarn5s::parameter_type &P2) {
-    return not(P1 == P2);
-  }
-
-  // Equality comparable concept
-  bool operator==(const yarn5s::status_type &S1, const yarn5s::status_type &S2) {
-    return S1.r1 == S2.r1 and S1.r2 == S2.r2 and S1.r3 == S2.r3 and S1.r4 == S2.r4 and
-           S1.r5 == S2.r5;
-  }
-
-  bool operator!=(const yarn5s::status_type &S1, const yarn5s::status_type &S2) {
-    return not(S1 == S2);
-  }
-
   const yarn5s::parameter_type yarn5s::trng0 =
       parameter_type(1053223373, 1530818118, 1612122482, 133497989, 573245311);
   const yarn5s::parameter_type yarn5s::trng1 =
       parameter_type(2068619238, 2138332912, 671754166, 1442240992, 1526958817);
 
   // Random number engine concept
-  yarn5s::yarn5s(const parameter_type &P) : P(P), S() {}
+  yarn5s::yarn5s(const parameter_type &P) : P{P} {}
 
-  yarn5s::yarn5s(unsigned long s, const parameter_type &P) : P(P), S() { seed(s); }
+  yarn5s::yarn5s(unsigned long s, const parameter_type &P) : P{P} { seed(s); }
 
   void yarn5s::seed() { (*this) = yarn5s(); }
 
@@ -75,30 +54,30 @@ namespace trng {
     t %= modulus;
     if (t < 0)
       t += modulus;
-    S.r1 = static_cast<result_type>(t);
-    S.r2 = 1;
-    S.r3 = 1;
-    S.r4 = 1;
-    S.r5 = 1;
+    S.r[0] = static_cast<result_type>(t);
+    S.r[1] = 1;
+    S.r[2] = 1;
+    S.r[3] = 1;
+    S.r[4] = 1;
   }
 
   void yarn5s::seed(yarn5s::result_type s1, yarn5s::result_type s2, yarn5s::result_type s3,
                     yarn5s::result_type s4, yarn5s::result_type s5) {
-    S.r1 = s1 % modulus;
-    if (S.r1 < 0)
-      S.r1 += modulus;
-    S.r2 = s2 % modulus;
-    if (S.r2 < 0)
-      S.r2 += modulus;
-    S.r3 = s3 % modulus;
-    if (S.r3 < 0)
-      S.r3 += modulus;
-    S.r4 = s4 % modulus;
-    if (S.r4 < 0)
-      S.r4 += modulus;
-    S.r5 = s5 % modulus;
-    if (S.r5 < 0)
-      S.r5 += modulus;
+    S.r[0] = s1 % modulus;
+    if (S.r[0] < 0)
+      S.r[0] += modulus;
+    S.r[1] = s2 % modulus;
+    if (S.r[1] < 0)
+      S.r[1] += modulus;
+    S.r[2] = s3 % modulus;
+    if (S.r[2] < 0)
+      S.r[2] += modulus;
+    S.r[3] = s4 % modulus;
+    if (S.r[3] < 0)
+      S.r[3] += modulus;
+    S.r[4] = s5 % modulus;
+    if (S.r[4] < 0)
+      S.r[4] += modulus;
   }
 
   // Equality comparable concept
@@ -111,6 +90,6 @@ namespace trng {
 
   const char *yarn5s::name() { return name_str; }
 
-  int_math::power<yarn5s::modulus, yarn5s::gen> yarn5s::parameter_type::g;
+  const int_math::power<yarn5s::modulus, yarn5s::gen> yarn5s::g;
 
 }  // namespace trng


### PR DESCRIPTION
See #18 for the intended upgrade to v4.23, and #21 for the the inclusion of the patch release v4.23.1, which fixes #16

In particular, the efforts described in #16 around reproducing and assessing `valgrind` issues based on the Docker image [wch1/r-debug](https://hub.docker.com/r/wch1/r-debug/) have been consolidated into a new GH actions workflow to automate such checks.
