### PR TITLE
Upgrade to the patched TRNG v4.23.1 released upstream

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^cran-comments\.md$
 LICENSE
 ^\.github$
+^valgrind-check$

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -1,0 +1,37 @@
+# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
+# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+on: [push, pull_request]
+
+name: valgrind
+
+jobs:
+  valgrind-check:
+    # Always run only on master, otherwise only if "[valgrind-check]" appears
+    # in the commit comment. An empty commit can be used as follows:
+    #   git commit --allow-empty -m 'Trigger [valgrind-check]'
+    if: contains(github.event.head_commit.message, '[valgrind-check]') || github.ref == 'refs/heads/master' || github.base_ref == 'refs/heads/master'
+
+    runs-on: ubuntu-latest
+
+    name: valgrind-check
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check with valgrind
+        run: bash inst/tools/valgrind-check.sh
+
+      - name: Detect valgrind issues
+        working-directory: valgrind-check
+        run: |
+          if grep -iv "ERROR SUMMARY: 0 errors" valgrind-summary; then
+            echo "::error ::Found valgrind errors"
+            exit 1
+          fi
+
+      - name: Upload valgrind results
+        if: always()
+        uses: actions/upload-artifact@main
+        with:
+          name: valgrind-results
+          path: valgrind-check

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/*.dll
 src/trng/*.o
 src/trng/*.so
 inst/doc
+valgrind-check

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rTRNG
 Title: Advanced and Parallel Random Number Generation via 'TRNG'
-Version: 4.23-0.9000
+Version: 4.23.1-0.9000
 Authors@R: 
     c(person("Riccardo", "Porreca", role = c("aut", "cre"),
              email = "riccardo.porreca@mirai-solutions.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # rTRNG (development version)
 
-- Underlying TRNG C++ library upgraded to version 4.23 (#18). This is a maintenance release, mainly including: Enhanced numerical accuracy of several special mathematical functions; Re-implementation of the discard method of the lagged Fibonacci generators with logarithmic asymptotic complexity.
-- Continuous integration is now based on GitHub Actions and covers R-release, R-oldrel and R-devel on Ubuntu, macOS and Windows (#14).
+- Underlying TRNG C++ library upgraded to version 4.23.1 (#20). This maintenance release, mainly including: Enhanced numerical accuracy of several special mathematical functions; Re-implementation of the discard method of the lagged Fibonacci generators with logarithmic asymptotic complexity. The release also fixes the uninitialized-memory problems reported as `valgrind` issues in the CRAN package checks for rTRNG 4.20-1 (#16).
+- Continuous integration is now based on GitHub Actions and covers R-release, R-oldrel and R-devel on Ubuntu, macOS and Windows (#14), as well as running checks with `valgrind` (#16).
 - Unit tests for "invalid argument" errors are now robust to systems where the error class does not propagate correctly to R, such as R 3.6.3 on macOS (#15).
 
 # rTRNG 4.22-1

--- a/R/TRNG.Version.R
+++ b/R/TRNG.Version.R
@@ -4,5 +4,5 @@
 #'
 #' @export
 TRNG.Version <- function() {
-  return("4.23")
+  return("4.23.1 (patched in rTRNG)")
 }

--- a/R/TRNG.Version.R
+++ b/R/TRNG.Version.R
@@ -4,5 +4,5 @@
 #'
 #' @export
 TRNG.Version <- function() {
-  return("4.23.1 (patched in rTRNG)")
+  return("4.23.1")
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,6 +40,7 @@ stop_if_no_vignette <- function(topic, package = "rTRNG") {
 
 [![CRAN status](http://www.r-pkg.org/badges/version/rTRNG)](https://cran.r-project.org/package=rTRNG)
 [![R-CMD-check](https://github.com/miraisolutions/rTRNG/workflows/R-CMD-check/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3AR-CMD-check)
+ [![valgrind](https://github.com/miraisolutions/rTRNG/workflows/valgrind/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3Avalgrind)
 [![Codecov coverage](https://codecov.io/gh/miraisolutions/rTRNG/branch/master/graph/badge.svg)](https://codecov.io/gh/miraisolutions/rTRNG?branch=master)
 
 **[TRNG](https://numbercrunch.de/trng/)** (Tina's Random Number Generator) is a

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![CRAN
 status](http://www.r-pkg.org/badges/version/rTRNG)](https://cran.r-project.org/package=rTRNG)
 [![R-CMD-check](https://github.com/miraisolutions/rTRNG/workflows/R-CMD-check/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3AR-CMD-check)
+[![valgrind](https://github.com/miraisolutions/rTRNG/workflows/valgrind/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3Avalgrind)
 [![Codecov
 coverage](https://codecov.io/gh/miraisolutions/rTRNG/branch/master/graph/badge.svg)](https://codecov.io/gh/miraisolutions/rTRNG?branch=master)
 

--- a/inst/include/trng/utility.hpp
+++ b/inst/include/trng/utility.hpp
@@ -89,9 +89,9 @@ namespace trng {
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
           std::basic_istream<char_t, traits_t> &in, const delim_str &d) {
-        char c;
+        char c{0};
         std::size_t len{std::strlen(d.str)}, i{0};
-        while (i < len and !(in.get(c) and c != d.str[i])) {
+        while (i < len and not(in.get(c) and c != d.str[i])) {
           ++i;
         }
         if (i < len)
@@ -108,9 +108,8 @@ namespace trng {
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
           std::basic_istream<char_t, traits_t> &in, const delim_c &d) {
-        char c;
-        in.get(c);
-        if (c != d.c)
+        char c{0};
+        if (not in.get(c).good() or c != d.c)
           in.setstate(std::ios::failbit);
         return in;
       }
@@ -127,9 +126,9 @@ namespace trng {
       template<typename char_t, typename traits_t>
       friend std::basic_istream<char_t, traits_t> &operator>>(
           std::basic_istream<char_t, traits_t> &in, const ignore_spaces_cl &) {
-        while (true) {
+        while (in.good()) {
           const int c(in.peek());
-          if (c == EOF or !(c == ' ' or c == '\t' or c == '\n'))
+          if (c == traits_t::eof() or not(c == ' ' or c == '\t' or c == '\n'))
             break;
           in.get();
         }

--- a/inst/tools/fix_uninitialized-memory_read_access-backport-v4.23.patch
+++ b/inst/tools/fix_uninitialized-memory_read_access-backport-v4.23.patch
@@ -1,0 +1,40 @@
+diff --git a/trng/utility.hpp b/trng/utility.hpp
+index 52b3739..458c3b1 100644
+--- a/trng/utility.hpp
++++ b/trng/utility.hpp
+@@ -89,9 +89,9 @@ namespace trng {
+       template<typename char_t, typename traits_t>
+       friend std::basic_istream<char_t, traits_t> &operator>>(
+           std::basic_istream<char_t, traits_t> &in, const delim_str &d) {
+-        char c;
++        char c{0};
+         std::size_t len{std::strlen(d.str)}, i{0};
+-        while (i < len and !(in.get(c) and c != d.str[i])) {
++        while (i < len and not(in.get(c) and c != d.str[i])) {
+           ++i;
+         }
+         if (i < len)
+@@ -108,9 +108,8 @@ namespace trng {
+       template<typename char_t, typename traits_t>
+       friend std::basic_istream<char_t, traits_t> &operator>>(
+           std::basic_istream<char_t, traits_t> &in, const delim_c &d) {
+-        char c;
+-        in.get(c);
+-        if (c != d.c)
++        char c{0};
++        if (not in.get(c).good() or c != d.c)
+           in.setstate(std::ios::failbit);
+         return in;
+       }
+@@ -127,9 +126,9 @@ namespace trng {
+       template<typename char_t, typename traits_t>
+       friend std::basic_istream<char_t, traits_t> &operator>>(
+           std::basic_istream<char_t, traits_t> &in, const ignore_spaces_cl &) {
+-        while (true) {
++        while (in.good()) {
+           const int c(in.peek());
+-          if (c == EOF or !(c == ' ' or c == '\t' or c == '\n'))
++          if (c == traits_t::eof() or not(c == ' ' or c == '\t' or c == '\n'))
+             break;
+           in.get();
+         }

--- a/inst/tools/upgradeTRNG.R
+++ b/inst/tools/upgradeTRNG.R
@@ -1,6 +1,6 @@
 if (FALSE) {
   source("inst/tools/upgradeTRNG.R")
-  upgradeTRNG(version = "4.23")
+  upgradeTRNG(version = "4.23.1")
   # with patch, packported from trng4 @22cc3b6:
   patch_file <- file.path(getwd(), "inst", "tools", "fix_uninitialized-memory_read_access-backport-v4.23.patch")
   system(paste0("cd ~/GitHubProjects/trng4/ && git diff v4.23..22cc3b6 trng/utility.hpp > ", patch_file))
@@ -14,7 +14,7 @@ upgradeTRNG <- function(version, base_url = "https://numbercrunch.de/trng",
                         cleanTmp = TRUE) {
 
   pre_4.22 <- package_version(version) < package_version("4.22")
-  gh_only <- package_version(version) == package_version("4.23")
+  gh_only <- package_version(version) >= package_version("4.23")
   lib.tar.gz <- sprintf("trng-%s.tar.gz", version)
   if (gh_only) {
     gh_base_url <- "https://github.com/rabauke/trng4/archive"

--- a/inst/tools/valgrind-check.sh
+++ b/inst/tools/valgrind-check.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Run R CMD check with valgrind to collect and detect reported errors.
+#
+# It is used by the valgrind GH actions workflow and can also be run locally,
+# provided Docker is available.
+
+mkdir -p valgrind-check
+
+# Note that we use -l and --install-args="--clean" in order to not have in the
+# valgrind-check directory (uploaded as artifact in GH actions) some large
+# directories and files produced as part of R CMD check
+docker run --rm -v $(pwd):/rTRNG wch1/r-debug bash -c ' \
+  RDvalgrind -e "install.packages(\"remotes\"); remotes::install_deps(\"rTRNG\", dependencies = TRUE)" \
+  && RDvalgrind CMD build /rTRNG \
+  && mkdir valgrind-check-lib \
+  && RDvalgrind -d "valgrind --track-origins=yes" CMD check \
+    -o /rTRNG/valgrind-check \
+    -l valgrind-check-lib \
+    --install-args="--clean" \
+    --use-valgrind --no-stop-on-test-error \
+    $(ls rTRNG_*.tar.gz) \
+  '
+
+# Collect valgrind "ERROR SUMMARY" lines from all log files
+grep -ri "ERROR SUMMARY" valgrind-check/rTRNG.Rcheck --exclude-dir=*pkg_src > valgrind-check/valgrind-summary
+cat valgrind-check/valgrind-summary

--- a/man/TRNG.Engine.Rd
+++ b/man/TRNG.Engine.Rd
@@ -271,7 +271,7 @@ TRNG.Random.seed(r$.Random.seed())
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23, \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1 (patched in rTRNG), \url{https://numbercrunch.de/trng/trng.pdf}.
 }
 \seealso{
 \code{\link{ReferenceClasses}}, \code{\link{TRNG.Random}}.

--- a/man/TRNG.Engine.Rd
+++ b/man/TRNG.Engine.Rd
@@ -271,7 +271,7 @@ TRNG.Random.seed(r$.Random.seed())
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23.1 (patched in rTRNG), \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1, \url{https://numbercrunch.de/trng/trng.pdf}.
 }
 \seealso{
 \code{\link{ReferenceClasses}}, \code{\link{TRNG.Random}}.

--- a/man/TRNG.Random.Rd
+++ b/man/TRNG.Random.Rd
@@ -195,7 +195,7 @@ c(TRNGseed(117),
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23, \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1 (patched in rTRNG), \url{https://numbercrunch.de/trng/trng.pdf}.
 }
 \seealso{
 TRNG distributions:

--- a/man/TRNG.Random.Rd
+++ b/man/TRNG.Random.Rd
@@ -195,7 +195,7 @@ c(TRNGseed(117),
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23.1 (patched in rTRNG), \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1, \url{https://numbercrunch.de/trng/trng.pdf}.
 }
 \seealso{
 TRNG distributions:

--- a/man/rTRNG-package.Rd
+++ b/man/rTRNG-package.Rd
@@ -62,7 +62,7 @@ cases.
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23.1 (patched in rTRNG), \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1, \url{https://numbercrunch.de/trng/trng.pdf}.
 
 Stephan Mertens, \emph{Random Number Generators: A Survival Guide
   for Large Scale Simulations}, 2009,

--- a/man/rTRNG-package.Rd
+++ b/man/rTRNG-package.Rd
@@ -62,7 +62,7 @@ cases.
 }
 \references{
 Heiko Bauke, \emph{Tina's Random Number Generator Library}, Version
-4.23, \url{https://numbercrunch.de/trng/trng.pdf}.
+4.23.1 (patched in rTRNG), \url{https://numbercrunch.de/trng/trng.pdf}.
 
 Stephan Mertens, \emph{Random Number Generators: A Survival Guide
   for Large Scale Simulations}, 2009,


### PR DESCRIPTION
Closes #16, see in particular https://github.com/miraisolutions/rTRNG/issues/16#issuecomment-769429098, to be integrated in #20 for merging into `master`.

The fix is backed by the introduction of continuous integration checks with `valgrind` via GitHub actions.

The functionality to include a locally-patched TRNG (see https://github.com/miraisolutions/rTRNG/issues/16#issuecomment-768659339) has been retained for reference and for possible future usage.