### PR TITLE
No multiarch R CMD check for r-devel on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         config:
           - {os: windows-latest, r: 'oldrel'}
           - {os: windows-latest, r: 'release'}
-          - {os: windows-latest, r: 'devel'}
+          - {os: windows-latest, r: 'devel', multiarch: '--no-multiarch'}
           - {os: macOS-latest, r: 'oldrel'}
           - {os: macOS-latest, r: 'release'}
           - {os: macOS-latest, r: 'devel'}
@@ -78,7 +78,11 @@ jobs:
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        run: |
+          rcmdcheck::rcmdcheck(
+            args = c("--no-manual", "--as-cran", "${{ matrix.config.multiarch }}"),
+            error_on = "warning", check_dir = "check"
+          )
         shell: Rscript {0}
 
       - name: Upload check results


### PR DESCRIPTION
* Checks on `i386` fail due to r-devel binaries currently built for `x64` only.