### PR TITLE
No multiarch package installs for r-devel on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Query dependencies
         run: |
-          install.packages('remotes')
+          install.packages("remotes", INSTALL_opts = "${{ matrix.config.multiarch }}")
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
@@ -71,8 +71,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
+          remotes::install_deps(dependencies = TRUE, INSTALL_opts = "${{ matrix.config.multiarch }}")
+          remotes::install_cran("rcmdcheck", INSTALL_opts = "${{ matrix.config.multiarch }}")
         shell: Rscript {0}
 
       - name: Check
@@ -95,6 +95,6 @@ jobs:
       - name: Test coverage
         if: success() && runner.os == 'Linux' && matrix.config.r == 'release'
         run: |
-          remotes::install_cran("covr")
+          remotes::install_cran("covr", INSTALL_opts = "${{ matrix.config.multiarch }}")
           covr::codecov(type = "all")
         shell: Rscript {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         config:
           - {os: windows-latest, r: 'oldrel'}
           - {os: windows-latest, r: 'release'}
-          - {os: windows-latest, r: 'devel'}
+          - {os: windows-latest, r: 'devel', multiarch: '--no-multiarch'}
           - {os: macOS-latest, r: 'oldrel'}
           - {os: macOS-latest, r: 'release'}
           - {os: macOS-latest, r: 'devel'}
@@ -78,7 +78,11 @@ jobs:
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        run: |
+          rcmdcheck::rcmdcheck(
+            args = c("--no-manual", "--as-cran", "${{ matrix.config.multiarch }}"),
+            error_on = "warning", check_dir = "check"
+          )
         shell: Rscript {0}
 
       - name: Upload check results


### PR DESCRIPTION
* Package installations from source (happening when binaries are not available yet for the latest version) can fail on `i386` due to r-devel binaries currently built for `x64` only.