### PR TITLE
Fix documentation image attribute + related / general maintenance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,6 @@ VignetteBuilder:
     knitr,
     R.rsp
 Encoding: UTF-8
-LazyData: true
 NeedsCompilation: yes
 RoxygenNote: 7.1.2
 Collate: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 NeedsCompilation: yes
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Collate: 
     'LdFlags.R'
     'RcppExports.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 - Continuous integration GitHub Actions workflow maintenance (#26, #24).
 - Fix invalid image height property attribute in the documentation (#25).
-- Fix redirected URLs in documentation and unnecessary LazyData in DESCRIPTION (#28).
+- Fix redirected URLs in documentation and remove unnecessary LazyData in DESCRIPTION (#28).
 
 # rTRNG 4.23.1-1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # rTRNG (development version)
 
 - Continuous integration GitHub Actions workflow maintenance (#26, #24).
+- Fix invalid image height property attribute in the documentation (#25).
+- Fix redirected URLs in documentation and unnecessary LazyData in DESCRIPTION (#28).
 
 # rTRNG 4.23.1-1
 

--- a/R/rTRNG-package.R
+++ b/R/rTRNG-package.R
@@ -13,7 +13,7 @@
 #' for parallel algorithms. See \sQuote{References} for an introduction to the
 #' concepts and details around (parallel) random number generation.
 #'
-#' \if{html}{\figure{rTRNG.svg}{options: height="150px" alt="rTRNG"}}
+#' \if{html}{\figure{rTRNG.svg}{options: height="150" alt="rTRNG"}}
 #'
 #' Package \pkg{rTRNG} provides the \R users with access to the functionality of
 #' the underlying TRNG C++ library in different ways and at different levels.

--- a/R/rTRNG-package.R
+++ b/R/rTRNG-package.R
@@ -6,7 +6,7 @@
 #'
 #' Tina's Random Number Generator Library (\pkg{TRNG}) is a state-of-the-art C++
 #' pseudo-random number generator library for sequential and parallel Monte
-#' Carlo simulations (\url{https://numbercrunch.de/trng/}). It provides a variety
+#' Carlo simulations (\url{https://www.numbercrunch.de/trng/}). It provides a variety
 #' of random number engines (pseudo-random number generators) and distributions.
 #' In particular, \emph{parallel} random number engines provided by TRNG support
 #' techniques such as \emph{block-splitting} and \emph{leapfrogging} suitable

--- a/README.Rmd
+++ b/README.Rmd
@@ -5,19 +5,19 @@ output: github_document
 # Make sure you have added an executable pre-commit hook in your local checkout 
 #   .git/hooks/pre-commit
 # to prevent accidental commits of README.Rmd not re-knitted to README.md.
-# If not, you can copy the hook from inst/tools
-#   $ cp inst/tools/pre-commit .git/hooks
+# You can copy the hook from inst/tools using R via
+# usethis::use_git_hook("pre-commit", readLines("inst/tools/pre-commit", encoding="UTF-8"))
 ################################################################################
 ---
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-
-```{r, echo = FALSE}
+```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  fig.path = "README-",
+  fig.path = "man/figures/README-",
+  out.width = "100%",
   R.options = list(digits = 6, width = 60) # fit 5 elements per row
 )
 ```
@@ -38,10 +38,12 @@ stop_if_no_vignette <- function(topic, package = "rTRNG") {
 
 # rTRNG: R package providing access and examples to TRNG C++ library
 
+<!-- badges: start -->
 [![CRAN status](http://www.r-pkg.org/badges/version/rTRNG)](https://cran.r-project.org/package=rTRNG)
 [![R-CMD-check](https://github.com/miraisolutions/rTRNG/workflows/R-CMD-check/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3AR-CMD-check)
  [![valgrind](https://github.com/miraisolutions/rTRNG/workflows/valgrind/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3Avalgrind)
 [![Codecov coverage](https://codecov.io/gh/miraisolutions/rTRNG/branch/master/graph/badge.svg)](https://app.codecov.io/gh/miraisolutions/rTRNG/branch/master)
+<!-- badges: end -->
 
 **[TRNG](https://www.numbercrunch.de/trng/)** (Tina's Random Number Generator) is a
 state-of-the-art C++ pseudo-random number generator library for sequential and

--- a/README.Rmd
+++ b/README.Rmd
@@ -41,9 +41,9 @@ stop_if_no_vignette <- function(topic, package = "rTRNG") {
 [![CRAN status](http://www.r-pkg.org/badges/version/rTRNG)](https://cran.r-project.org/package=rTRNG)
 [![R-CMD-check](https://github.com/miraisolutions/rTRNG/workflows/R-CMD-check/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3AR-CMD-check)
  [![valgrind](https://github.com/miraisolutions/rTRNG/workflows/valgrind/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3Avalgrind)
-[![Codecov coverage](https://codecov.io/gh/miraisolutions/rTRNG/branch/master/graph/badge.svg)](https://codecov.io/gh/miraisolutions/rTRNG?branch=master)
+[![Codecov coverage](https://codecov.io/gh/miraisolutions/rTRNG/branch/master/graph/badge.svg)](https://app.codecov.io/gh/miraisolutions/rTRNG/branch/master)
 
-**[TRNG](https://numbercrunch.de/trng/)** (Tina's Random Number Generator) is a
+**[TRNG](https://www.numbercrunch.de/trng/)** (Tina's Random Number Generator) is a
 state-of-the-art C++ pseudo-random number generator library for sequential and
 parallel Monte Carlo simulations. It provides a variety of random number engines
 (pseudo-random number generators) and distributions. In particular, *parallel*

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ status](http://www.r-pkg.org/badges/version/rTRNG)](https://cran.r-project.org/p
 [![R-CMD-check](https://github.com/miraisolutions/rTRNG/workflows/R-CMD-check/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3AR-CMD-check)
 [![valgrind](https://github.com/miraisolutions/rTRNG/workflows/valgrind/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3Avalgrind)
 [![Codecov
-coverage](https://codecov.io/gh/miraisolutions/rTRNG/branch/master/graph/badge.svg)](https://codecov.io/gh/miraisolutions/rTRNG?branch=master)
+coverage](https://codecov.io/gh/miraisolutions/rTRNG/branch/master/graph/badge.svg)](https://app.codecov.io/gh/miraisolutions/rTRNG/branch/master)
 
-**[TRNG](https://numbercrunch.de/trng/)** (Tina’s Random Number
+**[TRNG](https://www.numbercrunch.de/trng/)** (Tina’s Random Number
 Generator) is a state-of-the-art C++ pseudo-random number generator
 library for sequential and parallel Monte Carlo simulations. It provides
 a variety of random number engines (pseudo-random number generators) and
@@ -29,7 +29,7 @@ as part of other projects combining R with C++.
 An [introduction to
 **rTRNG**](https://user2017.sched.com/event/Axpj/rtrng-advanced-parallel-random-number-generation-in-r)
 \[[pdf](http://schd.ws/hosted_files/user2017/93/Mirai.rTRNG.useR2017.pdf)\]
-was given at the useR\!2017 conference, and is also available as package
+was given at the useR!2017 conference, and is also available as package
 vignette:
 
 ``` r
@@ -45,8 +45,8 @@ vignette("mcMat", "rTRNG")
 ```
 
 A full applied example of using **rTRNG** for the simulation of credit
-defaults was presented at the
-[R/Finance 2017](http://past.rinfinance.com/agenda/2017/talk/RiccardoPorreca.pdf)
+defaults was presented at the [R/Finance
+2017](http://past.rinfinance.com/agenda/2017/talk/RiccardoPorreca.pdf)
 conference. The underlying code and data are hosted on
 [GitHub](https://github.com/miraisolutions/PortfolioRiskMC), as is the
 corresponding [R Markdown
@@ -73,13 +73,13 @@ remotes::install_github("miraisolutions/rTRNG")
 remotes::install_github("miraisolutions/rTRNG", build_vignettes = TRUE)
 ```
 
------
+------------------------------------------------------------------------
 
 *Build note*
 
 If you try to build the package yourself from source and run
 `Rcpp::compileAttributes()` during the process, you need to use a
-version of **Rcpp \>= 0.12.11.2**. Earlier versions like 0.12.11 will
+version of **Rcpp &gt;= 0.12.11.2**. Earlier versions like 0.12.11 will
 not generate the desired `_rcpp_module_boot_trng` symbol in
 *RcppExports.cpp*.
 
@@ -143,7 +143,7 @@ identical(x_serial, x_parallel)
 The TRNG C++ library is made available by **rTRNG** to standalone C++
 code compiled with `Rcpp::sourceCpp` thanks to the `Rcpp::depends`
 attribute, with `Rcpp::plugins(cpp11)` enforcing the C++11 standard
-required by TRNG \>= 4.22:
+required by TRNG &gt;= 4.22:
 
 ``` cpp
 // [[Rcpp::depends(rTRNG)]]
@@ -176,18 +176,18 @@ exampleCpp()
 Creating an R package with C++ code using the TRNG library and headers
 through **rTRNG** is achieved by
 
-  - adding `Imports: rTRNG` and `LinkingTo: rTRNG` to the DESCRIPTION
+-   adding `Imports: rTRNG` and `LinkingTo: rTRNG` to the DESCRIPTION
     file
-  - importing one symbol in the NAMESPACE: `importFrom(rTRNG,
-    TRNG.Version)`
-  - enforcing compilation using C++11 in Makevars\[.win\] via `CXX_STD =
-    CXX11`
-  - setting the relevant linker flags in Makevars\[.win\] via
+-   importing one symbol in the NAMESPACE:
+    `importFrom(rTRNG, TRNG.Version)`
+-   enforcing compilation using C++11 in Makevars\[.win\] via
+    `CXX_STD = CXX11`
+-   setting the relevant linker flags in Makevars\[.win\] via
     `rTRNG::LdFlags()`
-      - Makevars: `PKG_LIBS += $(shell ${R_HOME}/bin/Rscript -e
-        "rTRNG::LdFlags()")`
-      - Makevars.win: `PKG_LIBS += $(shell
-        "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "rTRNG::LdFlags()")`
+    -   Makevars:
+        `PKG_LIBS += $(shell ${R_HOME}/bin/Rscript -e "rTRNG::LdFlags()")`
+    -   Makevars.win:
+        `PKG_LIBS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "rTRNG::LdFlags()")`
 
 ### Note about C++ code on macOS
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@
 
 # rTRNG: R package providing access and examples to TRNG C++ library
 
+<!-- badges: start -->
+
 [![CRAN
 status](http://www.r-pkg.org/badges/version/rTRNG)](https://cran.r-project.org/package=rTRNG)
 [![R-CMD-check](https://github.com/miraisolutions/rTRNG/workflows/R-CMD-check/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3AR-CMD-check)
 [![valgrind](https://github.com/miraisolutions/rTRNG/workflows/valgrind/badge.svg)](https://github.com/miraisolutions/rTRNG/actions?query=workflow%3Avalgrind)
 [![Codecov
 coverage](https://codecov.io/gh/miraisolutions/rTRNG/branch/master/graph/badge.svg)](https://app.codecov.io/gh/miraisolutions/rTRNG/branch/master)
+<!-- badges: end -->
 
 **[TRNG](https://www.numbercrunch.de/trng/)** (Tina’s Random Number
 Generator) is a state-of-the-art C++ pseudo-random number generator

--- a/inst/tools/pre-commit
+++ b/inst/tools/pre-commit
@@ -1,5 +1,15 @@
 #!/bin/bash
+README=($(git diff --cached --name-only | grep -Ei '^README\.[R]?md$'))
+MSG="use 'git commit --no-verify' to override this check"
+
+if [[ ${#README[@]} == 0 ]]; then
+  exit 0
+fi
+
 if [[ README.Rmd -nt README.md ]]; then
-  echo "README.md is out of date; please re-knit README.Rmd"
+  echo -e "README.md is out of date; please re-knit README.Rmd\n$MSG"
+  exit 1
+elif [[ ${#README[@]} -lt 2 ]]; then
+  echo -e "README.Rmd and README.md should be both staged\n$MSG"
   exit 1
 fi

--- a/inst/tools/upgradeTRNG.R
+++ b/inst/tools/upgradeTRNG.R
@@ -23,7 +23,7 @@ upgradeTRNG <- function(version, base_url = "https://numbercrunch.de/trng",
     docURL <- sprintf("%s/blob/v%s/doc/trng.pdf", gh_base_url, version)
   } else {
     libURL <- sprintf("%s/%s", base_url, lib.tar.gz)
-    docURL <- "https://numbercrunch.de/trng/trng.pdf"
+    docURL <- "https://www.numbercrunch.de/trng/trng.pdf"
   }
   tmpDir <- tempdir()
   lib.tar.gz.path <- file.path(tmpDir, lib.tar.gz)

--- a/man/rTRNG-package.Rd
+++ b/man/rTRNG-package.Rd
@@ -8,7 +8,7 @@
 \description{
 Tina's Random Number Generator Library (\pkg{TRNG}) is a state-of-the-art C++
 pseudo-random number generator library for sequential and parallel Monte
-Carlo simulations (\url{https://numbercrunch.de/trng/}). It provides a variety
+Carlo simulations (\url{https://www.numbercrunch.de/trng/}). It provides a variety
 of random number engines (pseudo-random number generators) and distributions.
 In particular, \emph{parallel} random number engines provided by TRNG support
 techniques such as \emph{block-splitting} and \emph{leapfrogging} suitable

--- a/man/rTRNG-package.Rd
+++ b/man/rTRNG-package.Rd
@@ -15,7 +15,7 @@ techniques such as \emph{block-splitting} and \emph{leapfrogging} suitable
 for parallel algorithms. See \sQuote{References} for an introduction to the
 concepts and details around (parallel) random number generation.
 
-\if{html}{\figure{rTRNG.svg}{options: height="150px" alt="rTRNG"}}
+\if{html}{\figure{rTRNG.svg}{options: height="150" alt="rTRNG"}}
 
 Package \pkg{rTRNG} provides the \R users with access to the functionality of
 the underlying TRNG C++ library in different ways and at different levels.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // C_runif_trng
 NumericVector C_runif_trng(const int n, const double min, const double max, S4 engine, const long parallelGrain);
 RcppExport SEXP _rTRNG_C_runif_trng(SEXP nSEXP, SEXP minSEXP, SEXP maxSEXP, SEXP engineSEXP, SEXP parallelGrainSEXP) {

--- a/vignettes/rTRNG.Rmd
+++ b/vignettes/rTRNG.Rmd
@@ -29,7 +29,7 @@ results are independent of the architecture, parallelization techniques and
 number of parallel processes.
 
 **rTRNG** is an R package for advanced parallel Random Number Generation in
-R. It relies on **[TRNG](https://numbercrunch.de/trng/)** (Tina's Random Number
+R. It relies on **[TRNG](https://www.numbercrunch.de/trng/)** (Tina's Random Number
 Generator), a state-of-the-art C++ pseudo-random number generator library for
 sequential and parallel Monte Carlo simulations.  In particular, *parallel*
 random number engines provided by TRNG can be manipulated by `jump` and `split`


### PR DESCRIPTION
This mainly fixes the invalid image height property attribute in the documentation, see #25 and specific commit 1a456b948eb6ac505df021b24c815564d0900151 for details.

In addition, we are also fixing redirected URLs in documentation and unnecessary `LazyData` in DESCRIPTION, including small related maintenance. See the respective individual commits for details.