### PR TITLE
pass token to codecov via covr

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,5 +60,5 @@ jobs:
         if: success() && runner.os == 'Linux' && matrix.config.r == 'release'
         run: |
           pak::pkg_install("any::covr")
-          covr::codecov(type = "all")
+          covr::codecov(type = "all", token = "${{ secrets.CODECOV_TOKEN }}")
         shell: Rscript {0}


### PR DESCRIPTION
As this is now required by codecov.io
