### PR TITLE
Fix package anchors in "Rd cross-references" + URLs in README => Prepare rTRNG 4.23.1-3 submission

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rTRNG
 Title: Advanced and Parallel Random Number Generation via 'TRNG'
-Version: 4.23.1-2.9000
+Version: 4.23.1-3
 Authors@R: 
     c(person("Riccardo", "Porreca", role = c("aut", "cre"),
              email = "riccardo.porreca@mirai-solutions.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ VignetteBuilder:
     R.rsp
 Encoding: UTF-8
 NeedsCompilation: yes
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.2
 Collate: 
     'LdFlags.R'
     'RcppExports.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
-# rTRNG (development version)
+# rTRNG 4.23.1-3
+
+## Patch release
 
 - Fix missing package anchors in the documentation (#33).
 - Fix Mirai.rTRNG.useR2017.pdf URL in the README (#34).
+- Maintenance of Continuous Integration GitHub Actions workflow (#29, #30, #31, #32).
 
 # rTRNG 4.23.1-2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rTRNG (development version)
 
+- Fix missing package anchors in the documentation (#33).
+- Fix Mirai.rTRNG.useR2017.pdf URL in the README (#34).
+
 # rTRNG 4.23.1-2
 
 ## Patch release

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Patch release
 
 - Fix missing package anchors in the documentation (#33).
-- Fix Mirai.rTRNG.useR2017.pdf URL in the README (#34).
+- Fix obsolete URLs in the README (#34).
 - Maintenance of Continuous Integration GitHub Actions workflow (#29, #30, #31, #32).
 
 # rTRNG 4.23.1-2

--- a/R/TRNG.Engine.R
+++ b/R/TRNG.Engine.R
@@ -90,7 +90,7 @@
 #' @section Details:
 #'
 #' Random number engines from the C++ TRNG library are exposed to \R using
-#' \pkg{\link{Rcpp}} \code{\linkS4class{Module}}s. As a consequence, the
+#' \pkg{\link[Rcpp]{Rcpp}} \code{\link[Rcpp:Module-class]{Module}}s. As a consequence, the
 #' arguments to all Constructors and Methods above are not passed by name but by
 #' order. Moreover, arguments and return values are both defined in terms of C++
 #' data types. Details can be displayed via the standard

--- a/R/rTRNG-package.R
+++ b/R/rTRNG-package.R
@@ -32,7 +32,7 @@
 #'     \itemize{
 #'     \item
 #'       Standalone C++ code sourced via \code{\link[Rcpp]{sourceCpp}} can rely
-#'       on the \code{\link[=dependsAttribute]{Rcpp::depends}} attribute to
+#'       on the \code{\link[Rcpp:dependsAttribute]{Rcpp::depends}} attribute to
 #'       correctly set up building against \pkg{rTRNG}, with
 #'       \code{Rcpp::plugins(cpp11)} enforcing the C++11 standard required by
 #'       TRNG >= 4.22:

--- a/README.Rmd
+++ b/README.Rmd
@@ -78,8 +78,9 @@ vignette("mcMat", "rTRNG")
 
 A full applied example of using **rTRNG** for the simulation of credit defaults
 was presented at the
-[R/Finance 2017](http://past.rinfinance.com/agenda/2017/talk/RiccardoPorreca.pdf)
-conference. The underlying code and data are hosted on [GitHub](https://github.com/miraisolutions/PortfolioRiskMC),
+[R/Finance 2017 conference](https://www.osqf.org/archive/2017/)
+[[pdf](https://rinfinance.s3.amazonaws.com/past.rinfinance.com/agenda/2017/talk/RiccardoPorreca.pdf)].
+The underlying code and data are hosted on [GitHub](https://github.com/miraisolutions/PortfolioRiskMC),
 as is the corresponding
 [R Markdown output](https://rawgit.com/miraisolutions/PortfolioRiskMC/master/RinFinance2017/PortfolioSimAndRiskBig.html).
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -59,7 +59,7 @@ other projects combining R with C++.
 
 An
 [introduction to **rTRNG**](https://user2017.sched.com/event/Axpj/rtrng-advanced-parallel-random-number-generation-in-r)
-[[pdf](http://schd.ws/hosted_files/user2017/93/Mirai.rTRNG.useR2017.pdf)]
+[[pdf](https://static.sched.com/hosted_files/user2017/93/Mirai.rTRNG.useR2017.pdf)]
 was given at the useR!2017 conference, and is also available as package
 vignette:
 ```{r check-vignettes, echo=FALSE}

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ vignette("mcMat", "rTRNG")
 ```
 
 A full applied example of using **rTRNG** for the simulation of credit
-defaults was presented at the [R/Finance
-2017](http://past.rinfinance.com/agenda/2017/talk/RiccardoPorreca.pdf)
-conference. The underlying code and data are hosted on
+defaults was presented at the [R/Finance 2017
+conference](https://www.osqf.org/archive/2017/)
+\[[pdf](https://rinfinance.s3.amazonaws.com/past.rinfinance.com/agenda/2017/talk/RiccardoPorreca.pdf)\].
+The underlying code and data are hosted on
 [GitHub](https://github.com/miraisolutions/PortfolioRiskMC), as is the
 corresponding [R Markdown
 output](https://rawgit.com/miraisolutions/PortfolioRiskMC/master/RinFinance2017/PortfolioSimAndRiskBig.html).

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ as part of other projects combining R with C++.
 
 An [introduction to
 **rTRNG**](https://user2017.sched.com/event/Axpj/rtrng-advanced-parallel-random-number-generation-in-r)
-\[[pdf](http://schd.ws/hosted_files/user2017/93/Mirai.rTRNG.useR2017.pdf)\]
+\[[pdf](https://static.sched.com/hosted_files/user2017/93/Mirai.rTRNG.useR2017.pdf)\]
 was given at the useR!2017 conference, and is also available as package
 vignette:
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -19,6 +19,13 @@ This submission addresses an explicit request by the CRAN Team to fix by 2025-09
   Specified C++11: please drop specification unless essential
     * C++11 is required by the underlying TRNG C++ library
 
+One win-builder R-release and R-devel, there is an additional NOTE
+
+* checking CRAN incoming feasibility ... NOTE
+  Found the following (possibly) invalid URLs:
+  URL: https://user2017.sched.com/event/Axpj/rtrng-advanced-parallel-random-number-generation-in-
+    * This is a false positive, the URL is valid
+
 ## Reverse dependencies
 
 The package has no reverse dependencies.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -19,11 +19,11 @@ This submission addresses an explicit request by the CRAN Team to fix by 2025-09
   Specified C++11: please drop specification unless essential
     * C++11 is required by the underlying TRNG C++ library
 
-One win-builder R-release and R-devel, there is an additional NOTE
+On win-builder R-release and R-devel, there is an additional NOTE
 
 * checking CRAN incoming feasibility ... NOTE
   Found the following (possibly) invalid URLs:
-  URL: https://user2017.sched.com/event/Axpj/rtrng-advanced-parallel-random-number-generation-in-
+  URL: https://user2017.sched.com/event/Axpj/rtrng-advanced-parallel-random-number-generation-in-r
     * This is a false positive, the URL is valid
 
 ## Reverse dependencies

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,25 +1,23 @@
 ## CRAN submission request
 
-This submission addresses an explicit request by the CRAN team to fix by 2022-03-16 a small issue in an Rd file which, when converted to HTML, has invalid image height attribute.
+This submission addresses an explicit request by the CRAN Team to fix by 2025-09-01 the NOTEs about Rd file(s) with Rd \link{} targets missing package anchors in the "Rd cross-references" check.
     
 ## Test environments
 
-* local ubuntu 20.04, R 4.1.3
-* ubuntu 20.04 (on GitHub Actions), R-oldrel 4.0.5, R-release 4.1.3, R-devel
-* macOS (on GitHub Actions), R-oldrel 4.0.5, R-release 4.1.3, R-devel
-* windows (on GitHub Actions), R-oldrel 4.0.5, R-release 4.1.3, R-devel
+* local ubuntu 22.04, R 4.5.1
+* ubuntu 24.04 (on GitHub Actions), R-oldrel 4.4.3, R-release 4.5.1, R-devel
+* macOS (on GitHub Actions), R-oldrel 4.4.3, R-release 4.5.1, R-devel
+* windows (on GitHub Actions), R-oldrel 4.4.3, R-release 4.5.1, R-devel
 * docker-based R-devel compiled with valgrind level 2 instrumentation (on GitHub Actions)
-* win-builder R-oldrelease 4.0.5, R-release 4.1.3, R-devel
+* win-builder R-oldrelease 4.4.3, R-release 4.5.1, R-devel
 
 ## R CMD check results
 
-0 ERRORs | 0 WARNINGs | 2 NOTEs
+0 ERRORs | 0 WARNINGs | 1 NOTEs
 
-* checking installed package size ... NOTE
-    * Compiled code in the libs/ directory.
-    * Package vignettes in the doc/ directory.
-* checking for GNU extensions in Makefiles ... NOTE
-    * GNU make is a SystemRequirements.
+* checking C++ specification ... NOTE
+  Specified C++11: please drop specification unless essential
+    * C++11 is required by the underlying TRNG C++ library
 
 ## Reverse dependencies
 

--- a/man-roxygen/template-rdist.R
+++ b/man-roxygen/template-rdist.R
@@ -17,10 +17,10 @@
 #' @section Parallel Simulation: When a positive value of argument
 #'   \code{parallelGrain} is supplied, random variates are simulated in
 #'   parallel, provided a \emph{parallel} random number \code{engine} is
-#'   selected. This is done using \pkg{\link{RcppParallel}} via
+#'   selected. This is done using \pkg{\link[RcppParallel]{RcppParallel}} via
 #'   \code{parallelFor}, which uses the supplied \code{parallelGrain} to control
 #'   the grain size (the number of threads being controlled by
-#'   \code{\link{setThreadOptions}}). The grain size can greatly affect the overhead of
+#'   \code{\link[RcppParallel]{setThreadOptions}}). The grain size can greatly affect the overhead of
 #'   performing the required \emph{block splitting} \code{jump} operations and
 #'   should be selected carefully. Note that TRNG guarantees the outcome of such
 #'   parallel execution to be equivalent to a purely sequential simulation.

--- a/man/TRNG.Engine.Rd
+++ b/man/TRNG.Engine.Rd
@@ -126,7 +126,7 @@ period of the TRNG generators.
 
 
 Random number engines from the C++ TRNG library are exposed to \R using
-\pkg{\link{Rcpp}} \code{\linkS4class{Module}}s. As a consequence, the
+\pkg{\link[Rcpp]{Rcpp}} \code{\link[Rcpp:Module-class]{Module}}s. As a consequence, the
 arguments to all Constructors and Methods above are not passed by name but by
 order. Moreover, arguments and return values are both defined in terms of C++
 data types. Details can be displayed via the standard

--- a/man/rTRNG-package.Rd
+++ b/man/rTRNG-package.Rd
@@ -34,7 +34,7 @@ the underlying TRNG C++ library in different ways and at different levels.
     \itemize{
     \item
       Standalone C++ code sourced via \code{\link[Rcpp]{sourceCpp}} can rely
-      on the \code{\link[=dependsAttribute]{Rcpp::depends}} attribute to
+      on the \code{\link[Rcpp:dependsAttribute]{Rcpp::depends}} attribute to
       correctly set up building against \pkg{rTRNG}, with
       \code{Rcpp::plugins(cpp11)} enforcing the C++11 standard required by
       TRNG >= 4.22:

--- a/man/rbinom_trng.Rd
+++ b/man/rbinom_trng.Rd
@@ -31,10 +31,10 @@ Random number generation for the binomial distribution
  When a positive value of argument
   \code{parallelGrain} is supplied, random variates are simulated in
   parallel, provided a \emph{parallel} random number \code{engine} is
-  selected. This is done using \pkg{\link{RcppParallel}} via
+  selected. This is done using \pkg{\link[RcppParallel]{RcppParallel}} via
   \code{parallelFor}, which uses the supplied \code{parallelGrain} to control
   the grain size (the number of threads being controlled by
-  \code{\link{setThreadOptions}}). The grain size can greatly affect the overhead of
+  \code{\link[RcppParallel]{setThreadOptions}}). The grain size can greatly affect the overhead of
   performing the required \emph{block splitting} \code{jump} operations and
   should be selected carefully. Note that TRNG guarantees the outcome of such
   parallel execution to be equivalent to a purely sequential simulation.

--- a/man/rlnorm_trng.Rd
+++ b/man/rlnorm_trng.Rd
@@ -31,10 +31,10 @@ Random number generation for the log-normal distribution
  When a positive value of argument
   \code{parallelGrain} is supplied, random variates are simulated in
   parallel, provided a \emph{parallel} random number \code{engine} is
-  selected. This is done using \pkg{\link{RcppParallel}} via
+  selected. This is done using \pkg{\link[RcppParallel]{RcppParallel}} via
   \code{parallelFor}, which uses the supplied \code{parallelGrain} to control
   the grain size (the number of threads being controlled by
-  \code{\link{setThreadOptions}}). The grain size can greatly affect the overhead of
+  \code{\link[RcppParallel]{setThreadOptions}}). The grain size can greatly affect the overhead of
   performing the required \emph{block splitting} \code{jump} operations and
   should be selected carefully. Note that TRNG guarantees the outcome of such
   parallel execution to be equivalent to a purely sequential simulation.

--- a/man/rnorm_trng.Rd
+++ b/man/rnorm_trng.Rd
@@ -31,10 +31,10 @@ Random number generation for the normal distribution
  When a positive value of argument
   \code{parallelGrain} is supplied, random variates are simulated in
   parallel, provided a \emph{parallel} random number \code{engine} is
-  selected. This is done using \pkg{\link{RcppParallel}} via
+  selected. This is done using \pkg{\link[RcppParallel]{RcppParallel}} via
   \code{parallelFor}, which uses the supplied \code{parallelGrain} to control
   the grain size (the number of threads being controlled by
-  \code{\link{setThreadOptions}}). The grain size can greatly affect the overhead of
+  \code{\link[RcppParallel]{setThreadOptions}}). The grain size can greatly affect the overhead of
   performing the required \emph{block splitting} \code{jump} operations and
   should be selected carefully. Note that TRNG guarantees the outcome of such
   parallel execution to be equivalent to a purely sequential simulation.

--- a/man/rpois_trng.Rd
+++ b/man/rpois_trng.Rd
@@ -31,10 +31,10 @@ Random number generation for the Poisson distribution
  When a positive value of argument
   \code{parallelGrain} is supplied, random variates are simulated in
   parallel, provided a \emph{parallel} random number \code{engine} is
-  selected. This is done using \pkg{\link{RcppParallel}} via
+  selected. This is done using \pkg{\link[RcppParallel]{RcppParallel}} via
   \code{parallelFor}, which uses the supplied \code{parallelGrain} to control
   the grain size (the number of threads being controlled by
-  \code{\link{setThreadOptions}}). The grain size can greatly affect the overhead of
+  \code{\link[RcppParallel]{setThreadOptions}}). The grain size can greatly affect the overhead of
   performing the required \emph{block splitting} \code{jump} operations and
   should be selected carefully. Note that TRNG guarantees the outcome of such
   parallel execution to be equivalent to a purely sequential simulation.

--- a/man/runif_trng.Rd
+++ b/man/runif_trng.Rd
@@ -31,10 +31,10 @@ Random number generation for the uniform distribution
  When a positive value of argument
   \code{parallelGrain} is supplied, random variates are simulated in
   parallel, provided a \emph{parallel} random number \code{engine} is
-  selected. This is done using \pkg{\link{RcppParallel}} via
+  selected. This is done using \pkg{\link[RcppParallel]{RcppParallel}} via
   \code{parallelFor}, which uses the supplied \code{parallelGrain} to control
   the grain size (the number of threads being controlled by
-  \code{\link{setThreadOptions}}). The grain size can greatly affect the overhead of
+  \code{\link[RcppParallel]{setThreadOptions}}). The grain size can greatly affect the overhead of
   performing the required \emph{block splitting} \code{jump} operations and
   should be selected carefully. Note that TRNG guarantees the outcome of such
   parallel execution to be equivalent to a purely sequential simulation.


### PR DESCRIPTION
This mainly fixes the missing package anchors reported as "Rd cross-references" NOTE by R CMD check, closing #33.

In addition, we are also fixing obsolete URLs in the README, NOTEd by R CMD check:

- Mirai.rTRNG.useR2017.pdf:
  ```
   Found the following (possibly) invalid URLs:
     URL: http://schd.ws/hosted_files/user2017/93/Mirai.rTRNG.useR2017.pdf
       From: README.md
       Status: 403
       Message: Forbidden
  ```
- R/Finance 2017 slides link in README: The new link was taken from the rebranded osQF conference website https://www.osqf.org/archive/2017/.
  ```
  Found the following (possibly) invalid URLs:
    URL: http://past.rinfinance.com/agenda/2017/talk/RiccardoPorreca.pdf
      From: README.md
      Status: Error
      Message: libcurl error code 28:
        	Connection timed out after 60001 milliseconds
   ```