### PR TITLE
Specify C++ 17 as the required C++ standard => Prepare rTRNG 4.23.1-5 submission

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -16,7 +16,7 @@ jobs:
     name: valgrind-check
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Check with valgrind
         run: bash inst/tools/valgrind-check.sh

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rTRNG
 Title: Advanced and Parallel Random Number Generation via 'TRNG'
 Version: 4.23.1-4
-Authors@R: 
+Authors@R:
     c(person("Riccardo", "Porreca", role = c("aut", "cre"),
              email = "riccardo.porreca@mirai-solutions.com"),
       person("Roland", "Schmid", role = "aut",
@@ -21,7 +21,7 @@ License: GPL-3
 URL: https://github.com/miraisolutions/rTRNG#readme,
     https://mirai-solutions.ch
 BugReports: https://github.com/miraisolutions/rTRNG/issues
-SystemRequirements: GNU make
+SystemRequirements: GNU make, C++17
 Imports:
     methods,
     Rcpp (>= 0.11.6),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rTRNG
 Title: Advanced and Parallel Random Number Generation via 'TRNG'
-Version: 4.23.1-4
+Version: 4.23.1-5
 Authors@R:
     c(person("Riccardo", "Porreca", role = c("aut", "cre"),
              email = "riccardo.porreca@mirai-solutions.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - Specify C++ 17 as the required C++ standard, to avoid the R CMD check WARNING on R-devel `<ciso646> is not a standard header since C++20` (#39). This is meant as an interim solution waiting for an upstream patch of the TRNG C++ library (<https://github.com/rabauke/trng4/issues/34>).
 - Fix broken link to R/Finance 2017 conference applied example (#40).
-- Maintenance of Continuous Integration GitHub Actions workflow (#37).
+- Maintenance of Continuous Integration GitHub Actions workflow (#37, #38).
 
 # rTRNG 4.23.1-4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# rTRNG 4.23.1-5
+
+## Patch release
+
+- Specify C++ 17 as the required C++ standard, to avoid the R CMD check WARNING on R-devel `<ciso646> is not a standard header since C++20` (#39). This is meant as an interim solution waiting for an upstream patch of the TRNG C++ library (<https://github.com/rabauke/trng4/issues/34>).
+- Maintenance of Continuous Integration GitHub Actions workflow (#37).
+
 # rTRNG 4.23.1-4
 
 ## Patch release

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Patch release
 
 - Specify C++ 17 as the required C++ standard, to avoid the R CMD check WARNING on R-devel `<ciso646> is not a standard header since C++20` (#39). This is meant as an interim solution waiting for an upstream patch of the TRNG C++ library (<https://github.com/rabauke/trng4/issues/34>).
+- Fix broken link to R/Finance 2017 conference applied example (#40).
 - Maintenance of Continuous Integration GitHub Actions workflow (#37).
 
 # rTRNG 4.23.1-4

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,7 +1,7 @@
 ---
 output: github_document
 ################################################################################
-# NOTE: 
+# NOTE:
 # Make sure you have added an executable pre-commit hook in your local checkout 
 #   .git/hooks/pre-commit
 # to prevent accidental commits of README.Rmd not re-knitted to README.md.
@@ -82,7 +82,7 @@ was presented at the
 [[pdf](https://rinfinance.s3.amazonaws.com/past.rinfinance.com/agenda/2017/talk/RiccardoPorreca.pdf)].
 The underlying code and data are hosted on [GitHub](https://github.com/miraisolutions/PortfolioRiskMC),
 as is the corresponding
-[R Markdown output](https://rawgit.com/miraisolutions/PortfolioRiskMC/master/RinFinance2017/PortfolioSimAndRiskBig.html).
+[R Markdown output](https://mirai-solutions.ch/PortfolioRiskMC/RinFinance2017/PortfolioSimAndRiskBig.html).
 
 For more information and references, you can consult the package documentation
 page via `help("rTRNG-package")`.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ conference](https://www.osqf.org/archive/2017/)
 The underlying code and data are hosted on
 [GitHub](https://github.com/miraisolutions/PortfolioRiskMC), as is the
 corresponding [R Markdown
-output](https://rawgit.com/miraisolutions/PortfolioRiskMC/master/RinFinance2017/PortfolioSimAndRiskBig.html).
+output](https://mirai-solutions.ch/PortfolioRiskMC/RinFinance2017/PortfolioSimAndRiskBig.html).
 
 For more information and references, you can consult the package
 documentation page via `help("rTRNG-package")`.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -16,6 +16,15 @@ This submission addresses an explicit request by the CRAN Team to fix by 2026-03
 
 0 ERRORs | 0 WARNINGs | 0 NOTEs
 
+On win-builder, there are URLs in the README occasionally reported as possibly invalid in an additional NOTE:
+
+* checking CRAN incoming feasibility ... NOTE
+  Found the following (possibly) invalid URLs:
+  URL: https://static.sched.com/hosted_files/user2017/93/Mirai.rTRNG.useR2017.pdf
+  URL: https://user2017.sched.com/event/Axpj/rtrng-advanced-parallel-random-number-generation-in-r
+
+These are false positives, as the URLs are valid.
+
 ## Reverse dependencies
 
 The package has no reverse dependencies.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,30 +1,20 @@
-## CRAN resubmission
+## CRAN submission request
 
-In this resubmission I have dropped the C++11 specification to fix the remaining NOTE from "checking C++ specification".
-
-The original submission addressed an explicit request by the CRAN Team to fix by 2025-09-01 the NOTEs about Rd file(s) with Rd \link{} targets missing package anchors in the "Rd cross-references" check.
+This submission addresses an explicit request by the CRAN Team to fix by 2026-03-02 the R-devel WARNINGs about "ciso646 is not a standard header since C++20".
 
 ## Test environments
 
-* local ubuntu 22.04, R 4.5.1
-* ubuntu 24.04 (on GitHub Actions), R-oldrel 4.4.3, R-release 4.5.1, R-devel
-* macOS (on GitHub Actions), R-oldrel 4.4.3, R-release 4.5.1, R-devel
-* windows (on GitHub Actions), R-oldrel 4.4.3, R-release 4.5.1, R-devel
+* local ubuntu 24.04, R 4.5.2
+* local Fedora 42 (Docker container), R-devel, gcc 15.2.1
+* ubuntu 24.04 (on GitHub Actions), R-oldrel 4.4.3, R-release 4.5.2, R-devel
+* macOS (on GitHub Actions), R-oldrel 4.4.3, R-release 4.5.2, R-devel
+* windows (on GitHub Actions), R-oldrel 4.4.3, R-release 4.5.2, R-devel
 * docker-based R-devel compiled with valgrind level 2 instrumentation (on GitHub Actions)
-* win-builder R-oldrelease 4.4.3, R-release 4.5.1, R-devel
+* win-builder R-oldrelease 4.4.3, R-release 4.5.2, R-devel
 
 ## R CMD check results
 
 0 ERRORs | 0 WARNINGs | 0 NOTEs
-
-On win-builder R-release and R-devel, there are URLs in the README occasionally reported as possibly invalid in an additional NOTE:
-
-* checking CRAN incoming feasibility ... NOTE
-  Found the following (possibly) invalid URLs:
-  URL: https://static.sched.com/hosted_files/user2017/93/Mirai.rTRNG.useR2017.pdf
-  URL: https://user2017.sched.com/event/Axpj/rtrng-advanced-parallel-random-number-generation-in-r
-
-These are false positives, as the URLs are valid.
 
 ## Reverse dependencies
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,6 @@
 ## CRAN submission request
 
-This submission addresses an explicit request by the CRAN Team to fix by 2026-03-02 the R-devel WARNINGs about "ciso646 is not a standard header since C++20".
+This submission addresses an explicit request by the CRAN Team to fix by 2026-03-02 the R-devel WARNINGs about "ciso646 is not a standard header since C++20". A broken link in the README is also fixed.
 
 ## Test environments
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,6 @@
 # https://github.com/miraisolutions/rTRNG/issues/39
+# => remove (also from SystemRequirements) when addressed in TRNG
+#    (https://github.com/rabauke/trng4/issues/34)
 CXX_STD = CXX17
 
 PKG_LIBS += $(shell ${R_HOME}/bin/Rscript \

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,6 @@
+# https://github.com/miraisolutions/rTRNG/issues/39
+CXX_STD = CXX17
+
 PKG_LIBS += $(shell ${R_HOME}/bin/Rscript \
               -e "RcppParallel::RcppParallelLibs()")
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,6 @@
 # https://github.com/miraisolutions/rTRNG/issues/39
+# => remove (also from SystemRequirements) when addressed in TRNG
+#    (https://github.com/rabauke/trng4/issues/34)
 CXX_STD = CXX17
 
 PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,3 +1,6 @@
+# https://github.com/miraisolutions/rTRNG/issues/39
+CXX_STD = CXX17
+
 PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1
 
 PKG_LIBS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" \


### PR DESCRIPTION
This addresses the R CMD check WARNING about `<ciso646> is not a standard header since C++20`, see #39, so we can "correct before 2026-03-02 to safely retain your package on CRAN"

As part of a patch release rTRNG 4.23.1-5 submission preparation

- The no-longer-operational RawGit link to the  R/Finance 2017 conference applied example was replaced by a properly-deployed webpage
- #38 was updated to target this branch

